### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Niimbot Label Printer Home Assistant Integration
 
 ## Supported Models
 - B1 (confirmed)
-- B1 Pro (confirmed)
+- B21 Pro (confirmed)
 - D110 (confirmed)
 - other models with Bluetooth may work
 


### PR DESCRIPTION
There is no model called "B1 Pro". But the "B21 Pro" is.