### PR TITLE
Support additional printer models (D110_M, D11_H) in print logic

### DIFF
--- a/custom_components/niimbot/niimprint/printer.py
+++ b/custom_components/niimbot/niimprint/printer.py
@@ -233,7 +233,7 @@ class PrinterClient:
                     wait_between_print_lines,
                     print_line_batch_size,
                 )
-            elif model == PrinterModel.B21_PRO:
+            elif model in (PrinterModel.B21_PRO, PrinterModel.D110_M, PrinterModel.D11_H):
                 return await self.print_image_d110m_v4(
                     image,
                     density,


### PR DESCRIPTION
Expanded the conditional to include PrinterModel.D110_M and PrinterModel.D11_H alongside B21_PRO for the print_image_d110m_v4 method, enabling support for these models.