### PR TITLE
Add support for B1 Pro

### DIFF
--- a/custom_components/niimbot/niimprint/model.py
+++ b/custom_components/niimbot/niimprint/model.py
@@ -49,6 +49,7 @@ class PrinterModel(Enum):
     B21S_C2B = "B21S_C2B"
     P1S = "P1S"
     B1 = "B1"
+    B1_PRO = "B1_PRO"
     A8 = "A8"
     B21_C2B = "B21_C2B"
     Z401 = "Z401"
@@ -336,6 +337,14 @@ modelsLibrary: List[PrinterModelMeta] = [
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
         "printheadPixels": 384,
+        "paperTypes": [LabelType.WITH_GAPS, LabelType.BLACK, LabelType.TRANSPARENT],
+    },
+    {
+        "model": PrinterModel.B1_PRO,
+        "id": [4097],
+        "dpi": 300,
+        "printDirection": PrintDirection.TOP,
+        "printheadPixels": 567,
         "paperTypes": [LabelType.WITH_GAPS, LabelType.BLACK, LabelType.TRANSPARENT],
     },
     {


### PR DESCRIPTION
This pull request adds support for a new printer model, `B1_PRO`, to the `niimprint` module. The changes ensure the new model is recognized and its properties are properly defined.

New printer model support:

* Added `B1_PRO` to the `PrinterModel` enum in `model.py`, allowing it to be referenced throughout the codebase.
* Defined the metadata for the `B1_PRO` model in the `PrinterModelMeta` list, including its ID, DPI, print direction, printhead pixels, and supported paper types.

Note that this requires the dimensions: 567x354 due to the 300 DPI