### PR TITLE
Fix B1 Pro battery percentage reporting

### DIFF
--- a/custom_components/niimbot/niimprint/parser.py
+++ b/custom_components/niimbot/niimprint/parser.py
@@ -15,6 +15,12 @@ from .printer import PrinterClient, InfoEnum, SoundEnum
 from .model import PrinterModel, get_printer_meta_by_id
 import typing
 
+
+def _battery_percentage(powerlevel: int, model: str) -> float:
+    if model == PrinterModel.B1_PRO.name:
+        return powerlevel / 60.0 * 100.0
+    return float(powerlevel) * 25.0
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -191,7 +197,7 @@ class NiimbotDevice:
                 self.ble_data.sensors["closingstate"] = heartbeat["closingstate"]
                 self.ble_data.sensors["paperstate"] = heartbeat["paperstate"]
                 self.ble_data.sensors["rfidreadstate"] = heartbeat["rfidreadstate"]
-                self.ble_data.sensors["battery"] = float(heartbeat["powerlevel"]) * 25.0
+                self.ble_data.sensors["battery"] = _battery_percentage(heartbeat["powerlevel"], self.ble_data.model)
                 await printer.stop_notify()
             finally:
                 if not self.keep_connection:


### PR DESCRIPTION
## Problem

The B1 Pro printer reports its power level on a **0–60 scale**, while most other Niimbot models use a **0–4 scale**. The existing battery calculation in `parser.py` applied a hardcoded `* 25.0` multiplier designed for the 0–4 scale, which produced wildly incorrect values for the B1 Pro:

- Full charge (60) → **1500%** instead of 100%
- Partial charge (40) → **1000%** instead of ~67%

This was discovered by analysing the raw BLE heartbeat packets from a B1 Pro (device type `0x1001` / `4097`). The 13-byte heartbeat response places the power level at `data[10]`, and the B1 Pro was returning values in the range 0–60 rather than 0–4.

## Solution

Introduced a model-aware `_battery_percentage(powerlevel, model)` helper function that:

- For **B1_PRO**: calculates `powerlevel / 60.0 * 100.0`
- For **all other models**: keeps the existing `powerlevel * 25.0` behaviour (0–4 scale → 0–100%)

The `model` field on `BLEData` is always populated before the heartbeat call (it is resolved during the `DEVICETYPE` info exchange earlier in `update_device`), so no ordering issues are introduced.

## Changes

- `custom_components/niimbot/niimprint/parser.py`: added `_battery_percentage()` helper and updated the heartbeat battery assignment to use it.

## Testing

Verified against live BLE packet capture from a B1 Pro:
- Raw `powerlevel` byte: `0x28` (40 decimal)
- Before fix: `40 * 25.0 = 1000.0`
- After fix: `40 / 60.0 * 100.0 ≈ 66.7%` ✓