### PR TITLE
Fix three print reliability bugs affecting B1 Pro (model UNKNOWN, progress check, buffer desync)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Niimbot Label Printer Home Assistant Integration
 
 ## Gallery
 
-| B1 | B21 Pro | D110 |
+| B1 / B1 Pro | B21 Pro | D110 |
 | :---: | :---: | :---: |
-| <img src="https://raw.githubusercontent.com/eigger/hass-niimbot/master/docs/images/b1.jpg" width="300" alt="B1"> | <img src="https://raw.githubusercontent.com/eigger/hass-niimbot/master/docs/images/b21pro.jpg" width="370" alt="B21 Pro"> | <img src="https://raw.githubusercontent.com/eigger/hass-niimbot/master/docs/images/d110.jpg" width="300" alt="D110"> |
+| <img src="https://raw.githubusercontent.com/eigger/hass-niimbot/master/docs/images/b1.jpg" width="300" alt="B1 / B1 Pro"> | <img src="https://raw.githubusercontent.com/eigger/hass-niimbot/master/docs/images/b21pro.jpg" width="370" alt="B21 Pro"> | <img src="https://raw.githubusercontent.com/eigger/hass-niimbot/master/docs/images/d110.jpg" width="300" alt="D110"> |
 
 >[!IMPORTANT]
 >
@@ -36,6 +36,7 @@ Niimbot Label Printer Home Assistant Integration
 | Model | Status |
 |-------|--------|
 | B1 | confirmed |
+| B1 Pro | confirmed |
 | B21 Pro | confirmed |
 | D110 | confirmed |
 | Other models with Bluetooth | may work |

--- a/custom_components/niimbot/niimprint/parser.py
+++ b/custom_components/niimbot/niimprint/parser.py
@@ -209,10 +209,6 @@ class NiimbotDevice:
         wait_between_print_lines: float,
         print_line_batch_size: int,
     ) -> dict:
-        try:
-            printer_model = PrinterModel(self.model)
-        except ValueError:
-            printer_model = PrinterModel.UNKNOWN
         async with self.lock:
             # Reuse existing connection when keep_connection is enabled
             if not self.is_connected:
@@ -232,6 +228,24 @@ class NiimbotDevice:
             try:
                 printer = PrinterClient(self.client)
                 await printer.start_notify()
+
+                # Resolve model inside the lock so we never print with UNKNOWN
+                # if update_device hasn't run yet (e.g. first print after HA start).
+                if not self.model:
+                    device_type = await printer.get_info(InfoEnum.DEVICETYPE)
+                    if device_type is not None:
+                        meta = get_printer_meta_by_id(int(device_type))
+                        self.model = meta["model"].name if meta else str(device_type)
+                        self.ble_data.model = self.model
+                        self.ble_data.devicetype = device_type
+                        _LOGGER.debug("Resolved model during print: %s", self.model)
+
+                try:
+                    printer_model = PrinterModel(self.model)
+                except (ValueError, TypeError):
+                    printer_model = PrinterModel.UNKNOWN
+                    _LOGGER.warning("Unknown printer model %r, falling back to UNKNOWN", self.model)
+
                 await printer.print_image(
                     printer_model,
                     image,

--- a/custom_components/niimbot/niimprint/printer.py
+++ b/custom_components/niimbot/niimprint/printer.py
@@ -483,12 +483,24 @@ class PrinterClient:
         packets = []
         self._packetbuf.extend(await self._transport.read(1024))
         while len(self._packetbuf) > 4:
+            # Resync to the next 0x55 0x55 header, discarding any stale bytes
+            # left over from unsolicited mid-stream packets.
+            if self._packetbuf[0] != 0x55 or self._packetbuf[1] != 0x55:
+                skip = self._packetbuf.find(b"\x55\x55")
+                if skip == -1:
+                    self._packetbuf.clear()
+                    break
+                _LOGGER.debug("Resyncing packet buffer, skipping %d bytes", skip)
+                del self._packetbuf[:skip]
+                continue
             pkt_len = self._packetbuf[3] + 7
             if len(self._packetbuf) >= pkt_len:
                 packet = NiimbotPacket.from_bytes(self._packetbuf[:pkt_len])
                 self._log_buffer("recv", packet.to_bytes())
                 packets.append(packet)
                 del self._packetbuf[:pkt_len]
+            else:
+                break
         return packets
 
     async def _send(self, packet, response=True):
@@ -752,7 +764,11 @@ class PrinterClient:
             progress1,
             progress2,
         )
-        return {"page": page, "progress": min(progress1, progress2)}
+        # Some models (e.g. B1 Pro) report progress2=0 even when done;
+        # use the maximum of both non-zero values, falling back to whichever is non-zero.
+        active = [p for p in (progress1, progress2) if p > 0]
+        progress = max(active) if active else 0
+        return {"page": page, "progress": progress}
 
     async def get_print_end(self):
         status = await self.get_print_status()


### PR DESCRIPTION
Fixes #56

## Summary

Three bugs were identified by analysing a BLE debug log from a B1 Pro printer during a real print job. All three can cause the print to fail or crash.

---

## Bug 1 — Wrong print path when model is unknown at print time

**File:** `parser.py`

### Problem
`self.model` is populated by `update_device`, which runs on the coordinator poll cycle. If a print is triggered before the first successful poll (e.g. immediately after HA starts), `self.model` is `None`. `PrinterModel(None)` raises `ValueError`, which is caught and silently falls back to `PrinterModel.UNKNOWN`. That routes the job into `print_image_d11_v1` — the old D11 protocol — even on a B1 Pro. The wrong command sequence is sent, the print either fails or produces garbage output.

### Fix
Inside `print_image`, before choosing the print path, check if `self.model` is unset and resolve it on-the-fly via a `GET_INFO(DEVICETYPE)` exchange. This uses the already-open BLE connection and stores the result so subsequent prints don't repeat the query.

---

## Bug 2 — Print completion never detected

**File:** `printer.py` → `get_print_status`

### Problem
The B1 Pro responds to `GET_PRINT_STATUS` with `progress1=100, progress2=0` when printing is complete. The existing code computed `min(progress1, progress2)` = `min(100, 0)` = `0`, so `get_print_end()` always returned `False`. The polling loop ran for the full 5-second timeout on every print instead of exiting as soon as the printer confirmed completion.

### Fix
Replace `min()` with: take the maximum of all non-zero progress values. If both are zero, report 0. This correctly handles models that report one channel as 0 when done, while still being conservative for models that use both channels.

---

## Bug 3 — `AssertionError` crash from packet buffer desync

**File:** `printer.py` → `_recv`

### Problem
The printer occasionally sends unsolicited `D3` (print progress push) packets bundled with a normal response in the same BLE notification. When `_recv` processed the first packet and deleted it from `_packetbuf`, the leftover `D3` bytes remained. On the next `_recv` call, new data was appended to those stale bytes, `_packetbuf[3]` was now a byte from the middle of the old packet, and the computed `pkt_len` was wrong. `NiimbotPacket.from_bytes` was called on a slice that didn't start with `\x55\x55`, triggering `AssertionError`.

Observed in logs:
```
recv(10): 55:55:d3:03:00:c7:01:16:aa:aa   ← unsolicited push bundled before E4
recv(8):  55:55:e4:01:01:e4:aa:aa
```
The crash then occurred on the next status poll.

### Fix
Before parsing each packet, check that `_packetbuf` starts with `\x55\x55`. If not, scan forward to the next occurrence and discard everything before it. If no header is found, clear the buffer entirely. This makes the parser resilient to any mid-stream contamination.

---

## README

Added B1 Pro to the gallery (shares the B1 image, same form factor) and to the confirmed supported models table.

---

## Notes

All three bugs were identified from a real BLE debug log captured during a B1 Pro print. The fixes are based on analysis of that log and the existing code paths. Runtime verification on hardware would be welcome.