### PR TITLE
Convert printer state sensors to binary sensors; round battery percentage

### DIFF
--- a/custom_components/niimbot/binary_sensor.py
+++ b/custom_components/niimbot/binary_sensor.py
@@ -1,6 +1,7 @@
 """Support for niimbot ble binary sensors."""
 
 import logging
+import dataclasses
 
 from .niimprint import NiimbotDevice, BLEData
 
@@ -8,6 +9,7 @@ from homeassistant import config_entries
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
+    BinarySensorEntityDescription,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
@@ -21,6 +23,35 @@ from homeassistant.helpers.update_coordinator import (
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class NiimbotBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Binary sensor description with inversion flag."""
+    inverted: bool = False
+
+
+BINARY_SENSORS: list[NiimbotBinarySensorEntityDescription] = [
+    NiimbotBinarySensorEntityDescription(
+        key="closingstate",
+        name="Lid",
+        device_class=BinarySensorDeviceClass.DOOR,
+        icon="mdi:printer-alert",
+        # closingstate != 0 means open; door device class: is_on=True means open
+    ),
+    NiimbotBinarySensorEntityDescription(
+        key="paperstate",
+        name="Paper Loaded",
+        icon="mdi:label-outline",
+        # paperstate != 0 means paper is present
+    ),
+    NiimbotBinarySensorEntityDescription(
+        key="rfidreadstate",
+        name="RFID Readable",
+        icon="mdi:nfc-variant",
+        # rfidreadstate != 0 means readable
+    ),
+]
 
 
 async def async_setup_entry(
@@ -38,7 +69,48 @@ async def async_setup_entry(
         NiimbotConnectionBinarySensor(coordinator, coordinator.data, device),
     ]
 
+    for description in BINARY_SENSORS:
+        if description.key in coordinator.data.sensors:
+            entities.append(
+                NiimbotStateBinarySensor(coordinator, coordinator.data, description)
+            )
+
     async_add_entities(entities)
+
+
+class NiimbotStateBinarySensor(
+    CoordinatorEntity[DataUpdateCoordinator[BLEData]], BinarySensorEntity
+):
+    """Binary sensor for printer state values (lid, paper, RFID)."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[BLEData],
+        ble_data: BLEData,
+        description: NiimbotBinarySensorEntityDescription,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+        name = f"{ble_data.name} {ble_data.identifier}"
+        self._attr_unique_id = f"{name}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, ble_data.address)},
+            name=name,
+            manufacturer="Niimbot",
+            model=ble_data.model,
+            hw_version=ble_data.hw_version,
+            sw_version=ble_data.sw_version,
+            serial_number=ble_data.serial_number,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        value = self.coordinator.data.sensors.get(self.entity_description.key)
+        if value is None:
+            return None
+        return value != 0
 
 
 class NiimbotConnectionBinarySensor(

--- a/custom_components/niimbot/niimprint/parser.py
+++ b/custom_components/niimbot/niimprint/parser.py
@@ -16,10 +16,10 @@ from .model import PrinterModel, get_printer_meta_by_id
 import typing
 
 
-def _battery_percentage(powerlevel: int, model: str) -> float:
+def _battery_percentage(powerlevel: int, model: str) -> int:
     if model == PrinterModel.B1_PRO.name:
-        return powerlevel / 60.0 * 100.0
-    return float(powerlevel) * 25.0
+        return round(powerlevel / 60.0 * 100.0)
+    return round(float(powerlevel) * 25.0)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/niimbot/sensor.py
+++ b/custom_components/niimbot/sensor.py
@@ -38,25 +38,10 @@ SENSORS_MAPPING_TEMPLATE: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=PERCENTAGE,
         name="Battery",
     ),
-    "closingstate": SensorEntityDescription(
-        key="closingstate",
-        name="Closing State",
-        icon="mdi:printer-alert",
-    ),
     # "powerlevel": SensorEntityDescription(
     #     key="powerlevel",
     #     name="powerlevel",
     # ),
-    "paperstate": SensorEntityDescription(
-        key="paperstate",
-        name="Paper State",
-        icon="mdi:label-outline",
-    ),
-    "rfidreadstate": SensorEntityDescription(
-        key="rfidreadstate",
-        name="RFID Read State",
-        icon="mdi:nfc-variant",
-    ),
     # "density": SensorEntityDescription(
     #     key="density",
     #     name="density",


### PR DESCRIPTION
## Summary

Two improvements to the sensor entities, proposing a minor version bump.

---

## Change 1 — Convert printer state values to binary sensors

**Files:** `binary_sensor.py`, `sensor.py`

### Problem
`closingstate`, `paperstate`, and `rfidreadstate` were exposed as plain numeric sensors with no device class or unit of measurement. Their meaning was opaque in the HA UI — users would see raw integers (`0` or `1`) with names like "Closing State" and "RFID Read State", requiring knowledge of the protocol to interpret them.

### Change
Removed the three numeric sensors and replaced them with proper binary sensors:

| Old sensor | New binary sensor | Device class | On when |
|---|---|---|---|
| Closing State | **Lid** | `door` | lid is open |
| Paper State | **Paper Loaded** | — | paper is present |
| RFID Read State | **RFID Readable** | — | RFID tag is readable |

> ⚠️ **Breaking change**: existing HA automations or dashboards referencing `sensor.<device>_closing_state`, `sensor.<device>_paper_state`, or `sensor.<device>_rfid_read_state` will need to be updated to use the new `binary_sensor.<device>_lid`, `binary_sensor.<device>_paper_loaded`, and `binary_sensor.<device>_rfid_readable` entities.

---

## Change 2 — Round battery percentage to whole number

**File:** `parser.py`

### Problem
The B1 Pro battery calculation (`powerlevel / 60.0 * 100.0`) produced fractional values like `66.666...%`, which are not meaningful for a battery indicator sensor.

### Change
Applied `round()` to the result of `_battery_percentage()` for all models, returning an `int` instead of `float`. The standard 0–4 scale models are unaffected in practice since `n * 25.0` already produces whole numbers.

---

## Version bump

Given the breaking entity rename, a minor version bump (1.7.2 → 1.8.0) is proposed.