### PR TITLE
Fix BleakCharacteristicNotFoundError after printer unavailable for extended period

### DIFF
--- a/custom_components/niimbot/niimprint/parser.py
+++ b/custom_components/niimbot/niimprint/parser.py
@@ -7,7 +7,7 @@ import time
 
 # from logging import Logger
 from PIL import Image, ImageOps
-from bleak import BleakClient, BleakError
+from bleak import BleakClient
 from bleak.backends.device import BLEDevice
 from bleak_retry_connector import establish_connection
 
@@ -141,7 +141,8 @@ class NiimbotDevice:
             # Reuse existing connection when keep_connection is enabled
             if not self.is_connected:
                 self.client = await establish_connection(
-                    BleakClient, ble_device, ble_device.address
+                    BleakClient, ble_device, ble_device.address,
+                    use_services_cache=False,
                 )
                 if not self.client.is_connected:
                     raise RuntimeError("could not connect to thermal printer")
@@ -222,7 +223,8 @@ class NiimbotDevice:
             # Reuse existing connection when keep_connection is enabled
             if not self.is_connected:
                 self.client = await establish_connection(
-                    BleakClient, ble_device, ble_device.address
+                    BleakClient, ble_device, ble_device.address,
+                    use_services_cache=False,
                 )
                 if not self.client.is_connected:
                     raise RuntimeError("could not connect to thermal printer")


### PR DESCRIPTION
## Summary

- After the printer has been off or out of range for a long time, `establish_connection` reuses a stale GATT services cache
- This causes `start_notify` to raise `BleakCharacteristicNotFoundError` even though the connection itself succeeded
- Restarting HA fixes it because it clears the cache — now we get the same effect without a restart
- Fix: pass `use_services_cache=False` to `establish_connection` in both `update_device` and `print_image`

## Root cause from log

The printer was unavailable for ~46 minutes (`23:33`–`00:19`). When a print was triggered, `establish_connection` returned a connected client with a stale (empty) cached service table, so `_resolve_characteristic` couldn't find `bef8d6c9-...`.

## Test plan

- [ ] Trigger a print immediately after HA start — should work as before
- [ ] Leave printer off/unreachable for 30+ minutes, then trigger a print — should succeed instead of throwing `BleakCharacteristicNotFoundError`
- [ ] Confirm `keep_connection=True` mode is also unaffected (this bug hit both modes)