### PR TITLE
Bump imagespec 0.4.0 and expose dither methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ From version 2.0.0, labels are rendered with **[imagespec](https://github.com/ei
 - **Rotation:** `rotate: 90/180/270` rotates the drawing and **swaps output width/height** (label-printer mode).
 - **Default font:** `ppb.ttf` in `custom_components/niimbot/fonts/`. Custom fonts also work from `www/fonts/`.
 - **`plot` element:** reads history from Home Assistant **Recorder**.
-- **`dither`:** set on the service call (or per element in the payload) to halftone photos/charts on a 2-color printer. Keep text and barcodes undithered for sharp edges — see [imagespec dithering docs](https://github.com/eigger/imagespec#dithering).
+- **`dither`:** service field or per-element payload key. Use `true`/`floyd` (or another method name) to halftone photos/charts on a 2-color printer; `false`/`none` for flat nearest. Keep text and barcodes undithered for sharp edges — see [imagespec dithering docs](https://github.com/eigger/imagespec/blob/main/docs/dithering.md).
 - **Layout:** prefer `row` / `column` / `stack` for stacked content instead of hand-calculated coordinates.
 
 ---
@@ -117,7 +117,7 @@ From version 2.0.0, labels are rendered with **[imagespec](https://github.com/ei
 | `width` | no | `400` | Label width in pixels (10–1600) |
 | `height` | no | `240` | Label height in pixels (10–1600) |
 | `density` | no | `3` | Print density 1–5 (some models max out at 3) |
-| `dither` | no | `false` | Floyd–Steinberg halftone for the whole label |
+| `dither` | no | `none` / `false` | Palette dither method (`none`, `floyd`, `atkinson`, `bayer8`, …). `true` ≡ `floyd`. |
 | `wait_between_print_lines` | no | `0.05` | Seconds between lines (overrides device option) |
 | `print_line_batch_size` | no | `1` | Lines per batch before confirmation (overrides device option) |
 | `preview` | no | `false` | Render only; do not send to the printer |

--- a/custom_components/niimbot/manifest.json
+++ b/custom_components/niimbot/manifest.json
@@ -47,7 +47,7 @@
   "issue_tracker": "https://www.github.com/eigger/hass-niimbot/issues",
   "name": "Niimbot",
   "requirements": [
-    "imagespec[datamatrix]==0.3.1"
+    "imagespec[datamatrix]==0.4.0"
   ],
   "version": "2.2.1"
 }

--- a/custom_components/niimbot/render.py
+++ b/custom_components/niimbot/render.py
@@ -51,7 +51,7 @@ def render_image(entity_id, service, hass):
             rotate=service.data.get("rotate", 0),
             rotate_mode="image",    # label printer: variable size, drawing rotates
             background=service.data.get("background", "white"),
-            dither=bool(service.data.get("dither", False)),
+            dither=service.data.get("dither", False),
             context=_make_context(hass, default_font="ppb.ttf", palette=["black", "white"]),
         )
     except RenderError as err:

--- a/custom_components/niimbot/services.yaml
+++ b/custom_components/niimbot/services.yaml
@@ -76,6 +76,24 @@ print:
         boolean:
     dither:
       required: false
-      example: false
+      example: none
       selector:
-        boolean:
+        select:
+          mode: dropdown
+          options:
+            - "none"
+            - "floyd"
+            - "atkinson"
+            - "jarvis"
+            - "stucki"
+            - "burkes"
+            - "sierra"
+            - "sierra2"
+            - "sierra-lite"
+            - "stevenson-arce"
+            - "bayer2"
+            - "bayer4"
+            - "bayer8"
+            - "bayer16"
+            - "clustered4"
+            - "clustered8"

--- a/custom_components/niimbot/strings.json
+++ b/custom_components/niimbot/strings.json
@@ -84,7 +84,7 @@
         },
         "dither": {
           "name": "Dither",
-          "description": "Apply Floyd-Steinberg dithering to the image. Default: false."
+          "description": "Palette dither method for the whole label (none, floyd, atkinson, bayer8, …). Boolean true/false still work (floyd/none). Default: none."
         }
       }
     }

--- a/custom_components/niimbot/translations/en.json
+++ b/custom_components/niimbot/translations/en.json
@@ -79,7 +79,7 @@
                 },
                 "dither": {
                     "name": "Dither",
-                    "description": "Apply Floyd-Steinberg dithering to the image. Default: false."
+                    "description": "Palette dither method for the whole label (none, floyd, atkinson, bayer8, …). Boolean true/false still work (floyd/none). Default: none."
                 }
             }
         }

--- a/custom_components/niimbot/translations/ko.json
+++ b/custom_components/niimbot/translations/ko.json
@@ -79,7 +79,7 @@
                 },
                 "dither": {
                     "name": "디더링",
-                    "description": "이미지에 플로이드-스타인버그 디더링을 적용합니다. 기본값: false."
+                    "description": "라벨 전체에 적용할 팔레트 디더 방법(none, floyd, atkinson, bayer8 등). true/false도 그대로 동작합니다(floyd/none). 기본값: none."
                 }
             }
         }

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -94,3 +94,23 @@ def test_render_image_dither():
     unique_dither = set(pixels_dither)
     assert (0, 0, 0) in unique_dither
     assert (255, 255, 255) in unique_dither
+
+
+def test_render_image_dither_method_string():
+    hass = MagicMock()
+    hass.config.path = MagicMock(return_value="/tmp/mock_fonts")
+    service = MagicMock()
+    service.data = {
+        "payload": [
+            {"type": "rectangle", "x_start": 0, "y_start": 0, "x_end": 10, "y_end": 10, "fill": "#808080", "outline": "#808080"}
+        ],
+        "width": 10,
+        "height": 10,
+        "rotate": 0,
+        "background": "white",
+        "dither": "atkinson",
+    }
+    img = render_image("dummy_entity", service, hass)
+    colors = {img.getpixel((x, y)) for y in range(img.height) for x in range(img.width)}
+    assert colors <= {(0, 0, 0), (255, 255, 255)}
+    assert len(colors) == 2


### PR DESCRIPTION
## Summary
- Bump `imagespec[datamatrix]` to **0.4.0**.
- Service `dither` field: boolean → select (`none`, `floyd`, `atkinson`, `bayer8`, … from `DITHER_METHODS`).
- Pass the value through to `imagespec.render` (remove `bool()` cast). Legacy `true`/`false` still work.

## Test plan
- [ ] Existing automations with `dither: true` / `false` still render as before
- [ ] Service UI shows dither method dropdown
- [ ] `dither: atkinson` / `bayer8` produces a halftone
- [ ] Unit tests for dither (bool + method string)