### PR TITLE
Remove service-level dither (use per-element only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ From version 2.0.0, labels are rendered with **[imagespec](https://github.com/ei
 | Element examples with preview images | [imagespec/docs/elements.md](https://github.com/eigger/imagespec/blob/main/docs/elements.md) |
 | All element fields & defaults | [imagespec README — Element Reference](https://github.com/eigger/imagespec#elements-reference) |
 | Layout, palette, LLM authoring guide | [imagespec/docs/authoring.md](https://github.com/eigger/imagespec/blob/main/docs/authoring.md) |
+| Dithering (per-element only) | [imagespec/docs/dithering.md](https://github.com/eigger/imagespec/blob/main/docs/dithering.md) |
 
 **Niimbot-specific behaviour:**
 
@@ -101,7 +102,7 @@ From version 2.0.0, labels are rendered with **[imagespec](https://github.com/ei
 - **Rotation:** `rotate: 90/180/270` rotates the drawing and **swaps output width/height** (label-printer mode).
 - **Default font:** `ppb.ttf` in `custom_components/niimbot/fonts/`. Custom fonts also work from `www/fonts/`.
 - **`plot` element:** reads history from Home Assistant **Recorder**.
-- **`dither`:** set on photos/charts in the **payload** (e.g. `dlimg` / `pie` with `dither: floyd`). There is no service-level dither — whole-label dither blurs text and barcodes. See [imagespec dithering docs](https://github.com/eigger/imagespec/blob/main/docs/dithering.md).
+- **Dithering:** not a service option. Put `dither` on individual payload elements that need it (photos, charts). Leave text/QR/barcodes without `dither`. See [dithering.md](https://github.com/eigger/imagespec/blob/main/docs/dithering.md).
 - **Layout:** prefer `row` / `column` / `stack` for stacked content instead of hand-calculated coordinates.
 
 ---
@@ -145,6 +146,36 @@ data:
       height: 80
   width: 400
   height: 240
+```
+
+### Per-element dither (photos / charts)
+
+Do **not** dither the whole label. Add `dither` only on elements that benefit (e.g. `dlimg`, `pie`):
+
+```yaml
+action: niimbot.print
+target:
+  device_id: <your device>
+data:
+  payload:
+    - type: text
+      value: Product
+      x: 10
+      y: 10
+      size: 28
+    - type: dlimg
+      url: "https://example.com/photo.jpg"
+      x: 10
+      y: 50
+      xsize: 180
+      ysize: 120
+      dither: floyd   # or atkinson, bayer8, …
+    - type: pie
+      x: 210
+      y: 50
+      radius: 50
+      values: "A,40,orange;B,60,blue"
+      dither: atkinson
 ```
 
 ### Model-specific sizes

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ From version 2.0.0, labels are rendered with **[imagespec](https://github.com/ei
 - **Rotation:** `rotate: 90/180/270` rotates the drawing and **swaps output width/height** (label-printer mode).
 - **Default font:** `ppb.ttf` in `custom_components/niimbot/fonts/`. Custom fonts also work from `www/fonts/`.
 - **`plot` element:** reads history from Home Assistant **Recorder**.
-- **Dithering:** not a service option. Put `dither` on individual payload elements that need it (photos, charts). Leave text/QR/barcodes without `dither`. See [dithering.md](https://github.com/eigger/imagespec/blob/main/docs/dithering.md).
+- **Dithering:** not a service option. Put `dither` on **photos and charts** in the payload — `dlimg`, `pie`, `diagram`, `plot`, `sparkline`, `progress_bar`, `gauge` — when they use off-palette colors. Leave text/QR/barcodes without `dither`. See [dithering.md](https://github.com/eigger/imagespec/blob/main/docs/dithering.md).
 - **Layout:** prefer `row` / `column` / `stack` for stacked content instead of hand-calculated coordinates.
 
 ---
@@ -150,7 +150,9 @@ data:
 
 ### Per-element dither (photos / charts)
 
-Do **not** dither the whole label. Add `dither` only on elements that benefit (e.g. `dlimg`, `pie`):
+Do **not** dither the whole label. Add `dither` on chart/media elements that use
+off-palette colors (`dlimg`, `pie`, `diagram`, `plot`, `sparkline`,
+`progress_bar`, `gauge`):
 
 ```yaml
 action: niimbot.print
@@ -161,21 +163,30 @@ data:
     - type: text
       value: Product
       x: 10
-      y: 10
+      y: 8
       size: 28
     - type: dlimg
       url: "https://example.com/photo.jpg"
       x: 10
-      y: 50
-      xsize: 180
-      ysize: 120
-      dither: floyd   # or atkinson, bayer8, …
+      y: 40
+      xsize: 120
+      ysize: 90
+      dither: floyd
     - type: pie
-      x: 210
-      y: 50
-      radius: 50
+      x: 150
+      y: 40
+      radius: 40
       values: "A,40,orange;B,60,blue"
       dither: atkinson
+    - type: diagram
+      x: 250
+      y: 40
+      width: 130
+      height: 90
+      bars:
+        values: "Mon,10;Tue,25;Wed,15;Thu,30"
+        color: orange
+      dither: bayer8
 ```
 
 ### Model-specific sizes

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ From version 2.0.0, labels are rendered with **[imagespec](https://github.com/ei
 - **Rotation:** `rotate: 90/180/270` rotates the drawing and **swaps output width/height** (label-printer mode).
 - **Default font:** `ppb.ttf` in `custom_components/niimbot/fonts/`. Custom fonts also work from `www/fonts/`.
 - **`plot` element:** reads history from Home Assistant **Recorder**.
-- **`dither`:** service field or per-element payload key. Use `true`/`floyd` (or another method name) to halftone photos/charts on a 2-color printer; `false`/`none` for flat nearest. Keep text and barcodes undithered for sharp edges — see [imagespec dithering docs](https://github.com/eigger/imagespec/blob/main/docs/dithering.md).
+- **`dither`:** set on photos/charts in the **payload** (e.g. `dlimg` / `pie` with `dither: floyd`). There is no service-level dither — whole-label dither blurs text and barcodes. See [imagespec dithering docs](https://github.com/eigger/imagespec/blob/main/docs/dithering.md).
 - **Layout:** prefer `row` / `column` / `stack` for stacked content instead of hand-calculated coordinates.
 
 ---
@@ -117,7 +117,6 @@ From version 2.0.0, labels are rendered with **[imagespec](https://github.com/ei
 | `width` | no | `400` | Label width in pixels (10–1600) |
 | `height` | no | `240` | Label height in pixels (10–1600) |
 | `density` | no | `3` | Print density 1–5 (some models max out at 3) |
-| `dither` | no | `none` / `false` | Palette dither method (`none`, `floyd`, `atkinson`, `bayer8`, …). `true` ≡ `floyd`. |
 | `wait_between_print_lines` | no | `0.05` | Seconds between lines (overrides device option) |
 | `print_line_batch_size` | no | `1` | Lines per batch before confirmation (overrides device option) |
 | `preview` | no | `false` | Render only; do not send to the printer |

--- a/custom_components/niimbot/render.py
+++ b/custom_components/niimbot/render.py
@@ -51,7 +51,7 @@ def render_image(entity_id, service, hass):
             rotate=service.data.get("rotate", 0),
             rotate_mode="image",    # label printer: variable size, drawing rotates
             background=service.data.get("background", "white"),
-            dither=service.data.get("dither", False),
+            dither=False,
             context=_make_context(hass, default_font="ppb.ttf", palette=["black", "white"]),
         )
     except RenderError as err:

--- a/custom_components/niimbot/services.yaml
+++ b/custom_components/niimbot/services.yaml
@@ -74,26 +74,3 @@ print:
       example: 'false'
       selector:
         boolean:
-    dither:
-      required: false
-      example: none
-      selector:
-        select:
-          mode: dropdown
-          options:
-            - "none"
-            - "floyd"
-            - "atkinson"
-            - "jarvis"
-            - "stucki"
-            - "burkes"
-            - "sierra"
-            - "sierra2"
-            - "sierra-lite"
-            - "stevenson-arce"
-            - "bayer2"
-            - "bayer4"
-            - "bayer8"
-            - "bayer16"
-            - "clustered4"
-            - "clustered8"

--- a/custom_components/niimbot/strings.json
+++ b/custom_components/niimbot/strings.json
@@ -81,10 +81,6 @@
         "preview": {
           "name": "Preview the image data",
           "description": "Instead of printing, return the image as a base64-encoded URL."
-        },
-        "dither": {
-          "name": "Dither",
-          "description": "Palette dither method for the whole label (none, floyd, atkinson, bayer8, …). Boolean true/false still work (floyd/none). Default: none."
         }
       }
     }

--- a/custom_components/niimbot/translations/en.json
+++ b/custom_components/niimbot/translations/en.json
@@ -76,10 +76,6 @@
                 "preview": {
                     "name": "Preview the image data",
                     "description": "Instead of printing, return the image as a base64-encoded URL."
-                },
-                "dither": {
-                    "name": "Dither",
-                    "description": "Palette dither method for the whole label (none, floyd, atkinson, bayer8, …). Boolean true/false still work (floyd/none). Default: none."
                 }
             }
         }

--- a/custom_components/niimbot/translations/ko.json
+++ b/custom_components/niimbot/translations/ko.json
@@ -76,10 +76,6 @@
                 "preview": {
                     "name": "이미지 미리보기",
                     "description": "인쇄하는 대신 이미지를 base64 인코딩 URL로 반환합니다."
-                },
-                "dither": {
-                    "name": "디더링",
-                    "description": "라벨 전체에 적용할 팔레트 디더 방법(none, floyd, atkinson, bayer8 등). true/false도 그대로 동작합니다(floyd/none). 기본값: none."
                 }
             }
         }

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -51,14 +51,13 @@ def test_render_image_render_error():
         render_image("dummy_entity", service, hass)
 
 
-def test_render_image_dither():
-    # Arrange
+def test_render_image_per_element_dither():
+    """Service has no dither; use per-element dither for photos/charts only."""
     hass = MagicMock()
     hass.config.path = MagicMock(return_value="/tmp/mock_fonts")
 
-    # 1. Render without dither (flat)
-    service_no_dither = MagicMock()
-    service_no_dither.data = {
+    service_flat = MagicMock()
+    service_flat.data = {
         "payload": [
             {"type": "rectangle", "x_start": 0, "y_start": 0, "x_end": 10, "y_end": 10, "fill": "#808080", "outline": "#808080"}
         ],
@@ -66,51 +65,33 @@ def test_render_image_dither():
         "height": 10,
         "rotate": 0,
         "background": "white",
-        "dither": False
     }
-    img_no_dither = render_image("dummy_entity", service_no_dither, hass)
+    img_flat = render_image("dummy_entity", service_flat, hass)
 
-    # 2. Render with dither
     service_dither = MagicMock()
     service_dither.data = {
         "payload": [
-            {"type": "rectangle", "x_start": 0, "y_start": 0, "x_end": 10, "y_end": 10, "fill": "#808080", "outline": "#808080"}
+            {
+                "type": "rectangle",
+                "x_start": 0,
+                "y_start": 0,
+                "x_end": 10,
+                "y_end": 10,
+                "fill": "#808080",
+                "outline": "#808080",
+                "dither": "floyd",
+            }
         ],
         "width": 10,
         "height": 10,
         "rotate": 0,
         "background": "white",
-        "dither": True
     }
     img_dither = render_image("dummy_entity", service_dither, hass)
 
-    # Assert
-    w, h = img_no_dither.size
-    pixels_no_dither = [img_no_dither.getpixel((x, y)) for y in range(h) for x in range(w)]
-    unique_no_dither = set(pixels_no_dither)
-    assert len(unique_no_dither) == 1
+    w, h = img_flat.size
+    unique_flat = {img_flat.getpixel((x, y)) for y in range(h) for x in range(w)}
+    assert len(unique_flat) == 1
 
-    pixels_dither = [img_dither.getpixel((x, y)) for y in range(h) for x in range(w)]
-    unique_dither = set(pixels_dither)
-    assert (0, 0, 0) in unique_dither
-    assert (255, 255, 255) in unique_dither
-
-
-def test_render_image_dither_method_string():
-    hass = MagicMock()
-    hass.config.path = MagicMock(return_value="/tmp/mock_fonts")
-    service = MagicMock()
-    service.data = {
-        "payload": [
-            {"type": "rectangle", "x_start": 0, "y_start": 0, "x_end": 10, "y_end": 10, "fill": "#808080", "outline": "#808080"}
-        ],
-        "width": 10,
-        "height": 10,
-        "rotate": 0,
-        "background": "white",
-        "dither": "atkinson",
-    }
-    img = render_image("dummy_entity", service, hass)
-    colors = {img.getpixel((x, y)) for y in range(img.height) for x in range(img.width)}
-    assert colors <= {(0, 0, 0), (255, 255, 255)}
-    assert len(colors) == 2
+    unique_dither = {img_dither.getpixel((x, y)) for y in range(h) for x in range(w)}
+    assert unique_dither == {(0, 0, 0), (255, 255, 255)}


### PR DESCRIPTION
## Summary
- Remove the **service-level** `dither` field (`services.yaml`, translations, README).
- Always call `imagespec.render(..., dither=False)`; dither photos/charts via **per-element** `dither` in the payload instead.
- Update tests/examples accordingly. Legacy service `dither: true` is ignored (no longer in the schema).

## Why
Whole-label dither blurs text/QR/barcodes. Selective dither on `dlimg` / charts is the intended imagespec model.

## Test plan
- [ ] Service UI no longer shows a dither dropdown
- [ ] Payload element with `dither: floyd` still halftones that element only
- [ ] Existing automations that only set service `dither: true` become flat (document / migrate to per-element)
- [ ] Unit tests pass