### PR TITLE
Print copies, progress, info cache, and connection reuse

### DIFF
--- a/custom_components/niimbot/__init__.py
+++ b/custom_components/niimbot/__init__.py
@@ -199,15 +199,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 label_type=int(service.data["label_type"])
                 if "label_type" in service.data
                 else 1,
+                copies=int(service.data["copies"]) if "copies" in service.data else 1,
             )
             result["image"] = image_data
             return result
         except (PrinterError, RuntimeError, ValueError) as e:
             raise HomeAssistantError("Failed to print: %s" % e) from e
 
+    @callback
+    async def refresh_info_service(service: ServiceCall) -> ServiceResponse:
+        ble_device = bluetooth.async_ble_device_from_address(hass, address)
+        if ble_device is None:
+            raise HomeAssistantError(
+                f"could not find printer with address {address} through your Bluetooth network"
+            )
+        try:
+            data = await niimbot.refresh_info(ble_device)
+            coordinator.async_set_updated_data(data)
+            return {
+                "density": data.density,
+                "printspeed": data.printspeed,
+                "labeltype": data.labeltype,
+                "autoshutdowntime": data.autoshutdowntime,
+                "battery_bucket": niimbot._info_battery_bucket,
+            }
+        except Exception as e:
+            raise HomeAssistantError("Failed to refresh printer info: %s" % e) from e
+
     # register the services
     hass.services.async_register(
         DOMAIN, "print", printservice, supports_response=SupportsResponse.OPTIONAL
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "refresh_info",
+        refresh_info_service,
+        supports_response=SupportsResponse.OPTIONAL,
     )
 
     return True

--- a/custom_components/niimbot/binary_sensor.py
+++ b/custom_components/niimbot/binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
 from homeassistant.helpers.entity import DeviceInfo
@@ -37,19 +38,23 @@ BINARY_SENSORS: list[NiimbotBinarySensorEntityDescription] = [
         name="Lid",
         device_class=BinarySensorDeviceClass.DOOR,
         icon="mdi:printer-alert",
+        entity_category=EntityCategory.DIAGNOSTIC,
         # closingstate != 0 means open; door device class: is_on=True means open
     ),
     NiimbotBinarySensorEntityDescription(
         key="paperstate",
         name="Paper Loaded",
         icon="mdi:label-outline",
-        # Protocol: paperstate == 0 means inserted. Do not flip until HW-confirmed;
-        # inverted flag is wired and ready once confirmed.
+        entity_category=EntityCategory.DIAGNOSTIC,
+        # Protocol (Advanced1/2): paperstate == 0 means inserted. Confirmed on B1
+        # with stock loaded reporting Off when not inverted.
+        inverted=True,
     ),
     NiimbotBinarySensorEntityDescription(
         key="rfidreadstate",
         name="RFID Readable",
         icon="mdi:nfc-variant",
+        entity_category=EntityCategory.DIAGNOSTIC,
         # rfidreadstate != 0 means readable
     ),
 ]
@@ -125,6 +130,7 @@ class NiimbotConnectionBinarySensor(
     _attr_has_entity_name = True
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_icon = "mdi:bluetooth-connect"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,

--- a/custom_components/niimbot/niimprint/parser.py
+++ b/custom_components/niimbot/niimprint/parser.py
@@ -91,10 +91,16 @@ class NiimbotDevice:
             identifier=address.replace(":", "")[-6:],
             sensors={
                 "battery": None,
+                "battery_bucket": None,
                 "closingstate": None,
                 "paperstate": None,
                 "rfidreadstate": None,
                 "last_error": None,
+                "density": None,
+                "printspeed": None,
+                "labeltype": None,
+                "autoshutdowntime": None,
+                "print_progress": 0.0,
             }
         )
         self.client = None
@@ -102,15 +108,22 @@ class NiimbotDevice:
         self._heartbeat_payload: bytes | None = None
         self._last_rfid_uuid: str | None = None
         self._rfid_attrs: dict = {}
+        self._info_battery_bucket: int | None = None
+        self._info_loaded = False
         self.last_error: str | None = None
         self.last_error_time: float | None = None
         self.pending_events: list[dict] = []
         self.callback_connection = None
         self.callback_printing = None
         self.callback_error = None
+        self.callback_progress = None
         self._is_printing = False
         self._print_start_time: float | None = None
         self._print_end_time: float | None = None
+        self.print_progress: float = 0.0
+        self.print_page: int = 0
+        self.print_page_print_progress: int = 0
+        self.print_page_feed_progress: int = 0
         super().__init__()
 
     def get_model_meta(self):
@@ -187,6 +200,10 @@ class NiimbotDevice:
         if self.callback_printing:
             self.callback_printing()
 
+    def _notify_progress(self):
+        if self.callback_progress:
+            self.callback_progress()
+
     def _notify_error(self):
         if self.callback_error:
             self.callback_error()
@@ -199,6 +216,59 @@ class NiimbotDevice:
         self.last_error_time = time.time()
         self.ble_data.sensors["last_error"] = self.last_error
         self._notify_error()
+
+    def _handle_print_progress(self, status: dict) -> None:
+        self.print_page = int(status.get("page") or 0)
+        self.print_page_print_progress = int(status.get("page_print_progress") or 0)
+        self.print_page_feed_progress = int(status.get("page_feed_progress") or 0)
+        self.print_progress = float(status.get("progress") or 0)
+        self.ble_data.sensors["print_progress"] = self.print_progress
+        self._notify_progress()
+
+    async def _ensure_printer(self, ble_device: BLEDevice) -> PrinterClient:
+        """Connect and return a PrinterClient, reusing it when keep_connection is on."""
+        if not self.is_connected:
+            self.client = await establish_connection(
+                BleakClient,
+                ble_device,
+                ble_device.address,
+                use_services_cache=False,
+            )
+            if not self.client.is_connected:
+                raise RuntimeError("could not connect to thermal printer")
+            self._printer = None
+            self._notify_connection()
+
+        if self._printer is None:
+            self._printer = PrinterClient(
+                self.client, heartbeat_payload=self._heartbeat_payload
+            )
+            await self._printer.start_notify()
+        else:
+            self._printer._heartbeat_payload = self._heartbeat_payload
+        return self._printer
+
+    async def _release_printer(self) -> None:
+        """Stop notify / disconnect unless keep_connection holds the session open."""
+        if self._printer is not None and self._printer.heartbeat_payload is not None:
+            self._heartbeat_payload = self._printer.heartbeat_payload
+
+        if self.keep_connection and self.is_connected:
+            return
+
+        if self._printer is not None:
+            try:
+                await self._printer.stop_notify()
+            except Exception:
+                pass
+            self._printer = None
+
+        if self.client is not None:
+            try:
+                await self.client.disconnect()
+            except Exception:
+                pass
+            self._notify_connection()
 
     @property
     def is_connected(self) -> bool:
@@ -225,19 +295,64 @@ class NiimbotDevice:
 
     async def disconnect(self):
         """Disconnect from the BLE device if connected."""
-        if self.client and self.client.is_connected:
+        if self._printer is not None:
             try:
-                if self._printer:
-                    await self._printer.stop_notify()
+                await self._printer.stop_notify()
             except Exception:
                 pass
             finally:
                 self._printer = None
+        if self.client and self.client.is_connected:
             try:
                 await self.client.disconnect()
             except Exception:
                 pass
             self._notify_connection()
+
+    async def refresh_info(self, ble_device: BLEDevice) -> BLEData:
+        """Force-refresh cached PrinterInfo settings."""
+        async with self.lock:
+            if not self.ble_data.name:
+                self.ble_data.name = ble_device.name or "(no such device)"
+            printer = await self._ensure_printer(ble_device)
+            try:
+                await self._load_printer_info(printer, force=True)
+            finally:
+                await self._release_printer()
+            return self.ble_data
+
+    async def _load_printer_info(
+        self, printer: PrinterClient, force: bool = False
+    ) -> None:
+        """Read PrinterInfo settings once (or again when force=True)."""
+        if self._info_loaded and not force:
+            return
+
+        density = await printer.get_info(InfoEnum.DENSITY)
+        printspeed = await printer.get_info(InfoEnum.PRINTSPEED)
+        labeltype = await printer.get_info(InfoEnum.LABELTYPE)
+        autoshutdown = await printer.get_info(InfoEnum.AUTOSHUTDOWNTIME)
+        battery_bucket = await printer.get_info(InfoEnum.BATTERY)
+
+        if density is not None:
+            self.ble_data.density = int(density)
+            self.ble_data.sensors["density"] = self.ble_data.density
+        if printspeed is not None:
+            self.ble_data.printspeed = int(printspeed)
+            self.ble_data.sensors["printspeed"] = self.ble_data.printspeed
+        if labeltype is not None:
+            self.ble_data.labeltype = int(labeltype)
+            self.ble_data.sensors["labeltype"] = consumable_type_name(
+                self.ble_data.labeltype
+            )
+        if autoshutdown is not None:
+            self.ble_data.autoshutdowntime = int(autoshutdown)
+            self.ble_data.sensors["autoshutdowntime"] = self.ble_data.autoshutdowntime
+        if battery_bucket is not None:
+            self._info_battery_bucket = int(battery_bucket)
+            self.ble_data.sensors["battery_bucket"] = self._info_battery_bucket
+
+        self._info_loaded = True
 
     async def update_device(self, ble_device: BLEDevice) -> BLEData:
         """Connects to the device through BLE and retrieves relevant data"""
@@ -247,21 +362,8 @@ class NiimbotDevice:
             if not self.ble_data.address:
                 self.ble_data.address = ble_device.address
 
-            # Reuse existing connection when keep_connection is enabled
-            if not self.is_connected:
-                self.client = await establish_connection(
-                    BleakClient, ble_device, ble_device.address,
-                    use_services_cache=False,
-                )
-                if not self.client.is_connected:
-                    raise RuntimeError("could not connect to thermal printer")
-                self._notify_connection()
-
             try:
-                printer = PrinterClient(
-                    self.client, heartbeat_payload=self._heartbeat_payload
-                )
-                await printer.start_notify()
+                printer = await self._ensure_printer(ble_device)
                 if not self.ble_data.serial_number:
                     self.ble_data.serial_number = str(
                         await printer.get_info(InfoEnum.DEVICESERIAL)
@@ -288,14 +390,14 @@ class NiimbotDevice:
                         SoundEnum.BluetoothConnectionSound, self.use_sound
                     )
 
+                await self._load_printer_info(printer)
+
                 heartbeat = await printer.heartbeat(model_id=self.ble_data.devicetype)
                 if printer.heartbeat_payload is not None:
                     self._heartbeat_payload = printer.heartbeat_payload
                 self.ble_data.sensors["closingstate"] = heartbeat["closingstate"]
                 self.ble_data.sensors["paperstate"] = heartbeat["paperstate"]
                 self.ble_data.sensors["rfidreadstate"] = heartbeat["rfidreadstate"]
-                # Log raw polarity values so maintainers can confirm paperstate
-                # (protocol: 0 = inserted) before flipping the binary sensor.
                 _LOGGER.debug(
                     "Heartbeat raw: closingstate=%s paperstate=%s "
                     "rfidreadstate=%s powerlevel=%s variant=%s",
@@ -310,19 +412,19 @@ class NiimbotDevice:
                     self.ble_data.model,
                     variant=heartbeat.get("variant"),
                 )
-                # Always write so a missing powerlevel clears a stale reading.
+                # Prefer live heartbeat; fall back to cached PrinterInfo key 10.
+                if battery is None and self._info_battery_bucket is not None:
+                    battery = round(float(self._info_battery_bucket) * 25.0)
                 self.ble_data.sensors["battery"] = battery
+                if self._info_battery_bucket is not None:
+                    self.ble_data.sensors["battery_bucket"] = self._info_battery_bucket
 
                 await self._maybe_read_rfid(printer, heartbeat)
-
-                await printer.stop_notify()
             except PrinterTimeout as err:
                 _LOGGER.warning("Printer timed out during update: %s", err)
                 raise
             finally:
-                if not self.keep_connection:
-                    await self.client.disconnect()
-                    self._notify_connection()
+                await self._release_printer()
 
             _LOGGER.debug("Obtained BLEData: %s", self.ble_data)
             return self.ble_data
@@ -348,6 +450,7 @@ class NiimbotDevice:
             return
 
         self._apply_rfid_info(info)
+
     async def print_image(
         self,
         ble_device: BLEDevice,
@@ -356,32 +459,24 @@ class NiimbotDevice:
         wait_between_print_lines: float,
         print_line_batch_size: int,
         label_type: int = 1,
+        copies: int = 1,
     ) -> dict:
         async with self.lock:
-            # Reuse existing connection when keep_connection is enabled
-            if not self.is_connected:
-                self.client = await establish_connection(
-                    BleakClient, ble_device, ble_device.address,
-                    use_services_cache=False,
-                )
-                if not self.client.is_connected:
-                    raise RuntimeError("could not connect to thermal printer")
-                self._notify_connection()
-
-            # 프린트 시작
             self._is_printing = True
             self._print_start_time = time.time()
             self._print_end_time = None
+            self.print_progress = 0.0
+            self.print_page = 0
+            self.print_page_print_progress = 0
+            self.print_page_feed_progress = 0
+            self.ble_data.sensors["print_progress"] = 0.0
             self._notify_printing()
+            self._notify_progress()
 
             try:
-                printer = PrinterClient(
-                    self.client, heartbeat_payload=self._heartbeat_payload
-                )
-                await printer.start_notify()
+                printer = await self._ensure_printer(ble_device)
+                printer.on_progress = self._handle_print_progress
 
-                # Resolve model inside the lock so we never print with UNKNOWN
-                # if update_device hasn't run yet (e.g. first print after HA start).
                 if not self.model:
                     device_type = await printer.get_info(InfoEnum.DEVICETYPE)
                     if device_type is not None:
@@ -395,7 +490,9 @@ class NiimbotDevice:
                     printer_model = PrinterModel(self.model)
                 except (ValueError, TypeError):
                     printer_model = PrinterModel.UNKNOWN
-                    _LOGGER.warning("Unknown printer model %r, falling back to UNKNOWN", self.model)
+                    _LOGGER.warning(
+                        "Unknown printer model %r, falling back to UNKNOWN", self.model
+                    )
 
                 await printer.print_image(
                     printer_model,
@@ -404,25 +501,26 @@ class NiimbotDevice:
                     wait_between_print_lines,
                     print_line_batch_size,
                     label_type=label_type,
+                    copies=copies,
                 )
-                if printer.heartbeat_payload is not None:
-                    self._heartbeat_payload = printer.heartbeat_payload
-                await printer.stop_notify()
             except Exception as err:
                 self._record_error(err)
                 raise
             finally:
-                # 프린트 종료
+                if self._printer is not None:
+                    self._printer.on_progress = None
                 self._print_end_time = time.time()
                 self._is_printing = False
+                if self.print_progress < 100:
+                    self.print_progress = 100.0
+                    self.ble_data.sensors["print_progress"] = 100.0
                 self._notify_printing()
-
-                if not self.keep_connection:
-                    await self.client.disconnect()
-                    self._notify_connection()
+                self._notify_progress()
+                await self._release_printer()
 
         return {
             "status": "ok",
             "duration": self.print_duration,
+            "copies": copies,
         }
 

--- a/custom_components/niimbot/niimprint/parser.py
+++ b/custom_components/niimbot/niimprint/parser.py
@@ -430,16 +430,25 @@ class NiimbotDevice:
             return self.ble_data
 
     async def _maybe_read_rfid(self, printer: PrinterClient, heartbeat: dict) -> None:
-        """Read label RFID when the model supports it and the tag is ready."""
+        """Read label RFID when the model supports it."""
         if not self.supports_label_rfid():
             return
 
-        # Seed keys so entity platforms can discover them.
+        # Seed keys so entity platforms can discover them even before a tag read.
         for key in RFID_SENSOR_KEYS:
             self.ble_data.sensors.setdefault(key, None)
 
         rfid_ready = heartbeat.get("rfidreadstate")
-        if rfid_ready is not None and not rfid_ready:
+        # Still attempt a read when rfidreadstate is missing/unknown. Only skip
+        # the round-trip when the printer explicitly reports unreadiness as 0 —
+        # and even then fall through if we have never successfully read a tag,
+        # because some models (observed on B1) leave the flag at 0 with stock
+        # loaded.
+        if (
+            rfid_ready is not None
+            and not rfid_ready
+            and self._last_rfid_uuid is not None
+        ):
             _LOGGER.debug("Skipping RFID read: rfidreadstate falsy")
             return
 
@@ -506,14 +515,17 @@ class NiimbotDevice:
             except Exception as err:
                 self._record_error(err)
                 raise
+            else:
+                # Only mark 100% on a clean finish; leave the last reported
+                # value (and last_error) alone when the job failed.
+                if self.print_progress < 100:
+                    self.print_progress = 100.0
+                    self.ble_data.sensors["print_progress"] = 100.0
             finally:
                 if self._printer is not None:
                     self._printer.on_progress = None
                 self._print_end_time = time.time()
                 self._is_printing = False
-                if self.print_progress < 100:
-                    self.print_progress = 100.0
-                    self.ble_data.sensors["print_progress"] = 100.0
                 self._notify_printing()
                 self._notify_progress()
                 await self._release_printer()

--- a/custom_components/niimbot/niimprint/printer.py
+++ b/custom_components/niimbot/niimprint/printer.py
@@ -323,11 +323,7 @@ class PrinterClient:
             printhead_pixels=printhead_pixels,
         )
         await self.end_page_print()
-        start_time = time.time()
-        while not await self.get_print_end(copies=copies):
-            if time.time() - start_time > 5:
-                break
-            await sleep(0.5)
+        await self.wait_print_complete(copies=copies)
         await self.end_print()
 
     async def print_image_b1(
@@ -355,29 +351,7 @@ class PrinterClient:
             printhead_pixels=printhead_pixels,
         )
         await self.end_page_print()
-        # The B1/B1 Pro retains the *previous* job's progress=100 and reports it
-        # immediately after end_page_print, before it has reset the counter and
-        # started the new page. Trusting that stale 100% makes us call end_print()
-        # too early, which aborts the page: the printer feeds the label in and
-        # back out without printing (and the paper counter does not increment).
-        # So we wait until the printer has actually started the new page (we see
-        # progress drop below 100, or the page counter advance) before accepting
-        # a 100% as genuine completion. A timeout still guards against a hang.
-        start_time = time.time()
-        started = False
-        while True:
-            status = await self.get_print_status()
-            if status["progress"] < 100:
-                started = True
-            if status["page"] >= copies or (started and status["progress"] >= 100):
-                break
-            if time.time() - start_time > 30:
-                _LOGGER.warning(
-                    "Print completion not confirmed within timeout (last status: %s)",
-                    status,
-                )
-                break
-            await sleep(0.5)
+        await self.wait_print_complete(copies=copies)
         await self.end_print()
 
     async def print_image_d110(
@@ -406,11 +380,7 @@ class PrinterClient:
             printhead_pixels=printhead_pixels,
         )
         await self.end_page_print()
-        start_time = time.time()
-        while not await self.get_print_end(copies=copies):
-            if time.time() - start_time > 5:
-                break
-            await sleep(0.5)
+        await self.wait_print_complete(copies=copies)
         await self.end_print()
 
     async def print_image_d110m_v4(
@@ -444,11 +414,7 @@ class PrinterClient:
         if not await self.end_page_print():
             raise RuntimeError("Page did not finish successfully")
         await sleep(1)
-        start_time = time.time()
-        while not await self.get_print_end(copies=copies):
-            if time.time() - start_time > 5:
-                break
-            await sleep(0.1)
+        await self.wait_print_complete(copies=copies, poll_interval=0.1)
         if not await self.end_print():
             raise RuntimeError("Print did not finish successfully")
         await self.heartbeat(await_for_response=False)
@@ -1025,11 +991,48 @@ class PrinterClient:
             self.on_progress(status)
         return status
 
-    async def get_print_end(self, copies: int = 1):
-        status = await self.get_print_status()
-        _LOGGER.debug("Status: %s", status)
-        if status["page"] >= copies:
-            return True
-        if status["progress"] < 100:
-            return False
-        return True
+    async def wait_print_complete(
+        self,
+        copies: int = 1,
+        *,
+        timeout: float | None = None,
+        poll_interval: float = 0.5,
+    ) -> dict:
+        """Poll print status until all copies finish (or timeout).
+
+        Many models retain the previous job's progress=100 / page count right
+        after ``end_page_print``. Wait until progress drops below 100 before
+        treating completion as real — otherwise a leftover page count or a
+        stale 100% can call ``end_print()`` before imaging starts.
+
+        Multi-copy jobs require ``page >= copies``; progress alone must not
+        end the wait after the first label. Timeout scales with ``copies``.
+        """
+        if timeout is None:
+            timeout = max(30.0, 15.0 * max(1, copies))
+        start_time = time.time()
+        started = False
+        status: dict = {}
+        while True:
+            status = await self.get_print_status()
+            _LOGGER.debug("Status: %s", status)
+            page = status.get("page", 0)
+            progress = status.get("progress", 0)
+            if progress < 100:
+                started = True
+            if started and page >= copies:
+                break
+            # Printers that never bump the page counter (single-copy only).
+            if started and copies <= 1 and progress >= 100:
+                break
+            if time.time() - start_time > timeout:
+                _LOGGER.warning(
+                    "Print completion not confirmed within %.0fs "
+                    "(copies=%s, last status: %s)",
+                    timeout,
+                    copies,
+                    status,
+                )
+                break
+            await sleep(poll_interval)
+        return status

--- a/custom_components/niimbot/niimprint/printer.py
+++ b/custom_components/niimbot/niimprint/printer.py
@@ -236,6 +236,7 @@ class PrinterClient:
         self._timings: list[float] = []
         # Cached heartbeat request payload that previously succeeded (b"\x01" or b"\x04").
         self._heartbeat_payload: bytes | None = heartbeat_payload
+        self.on_progress: Callable[[dict], None] | None = None
 
     @property
     def heartbeat_payload(self) -> bytes | None:
@@ -255,11 +256,14 @@ class PrinterClient:
         wait_between_print_lines: float,
         print_line_batch_size: int,
         label_type: int = 1,
+        copies: int = 1,
     ):
         self._timings = []
         _LOGGER.debug("Printing on printer model %s", model)
         start = time.time()
         try:
+            if copies < 1:
+                raise ValueError(f"copies must be >= 1, got {copies}")
             meta = get_printer_meta_by_model(model)
             printhead_pixels = meta["printheadPixels"] if meta else None
             density_min = meta.get("densityMin", 1) if meta else 1
@@ -273,6 +277,7 @@ class PrinterClient:
                 label_type=label_type,
                 density_min=density_min,
                 density_max=density_max,
+                copies=copies,
             )
             if model in (PrinterModel.UNKNOWN, PrinterModel.D11, PrinterModel.D11S):
                 return await self.print_image_d11_v1(**kwargs)
@@ -300,6 +305,7 @@ class PrinterClient:
         label_type: int = 1,
         density_min: int = 1,
         density_max: int = 5,
+        copies: int = 1,
     ):
         """Print task for older D11 printers (OldD11PrintTask from niimblue)."""
         _LOGGER.debug("print_image_d11_v1: %s", locals())
@@ -309,7 +315,7 @@ class PrinterClient:
         await self.allow_print_clear()
         await self.start_page_print()
         await self.set_page_size_v2(image.height, 0)  # D11_V1 only sends height
-        await self.set_quantity(1)
+        await self.set_quantity(copies)
         await self.set_image(
             image,
             wait_between_print_lines,
@@ -318,7 +324,7 @@ class PrinterClient:
         )
         await self.end_page_print()
         start_time = time.time()
-        while not await self.get_print_end():
+        while not await self.get_print_end(copies=copies):
             if time.time() - start_time > 5:
                 break
             await sleep(0.5)
@@ -334,13 +340,14 @@ class PrinterClient:
         label_type: int = 1,
         density_min: int = 1,
         density_max: int = 5,
+        copies: int = 1,
     ):
         _LOGGER.debug("print_image_b1: %s", locals())
         await self.set_label_density(density, density_min, density_max)
         await self.set_label_type(label_type)
-        await self.start_print_v4()
+        await self.start_print_v4(total_pages=1)
         await self.start_page_print()
-        await self.set_page_size_v3(image.height, image.width)
+        await self.set_page_size_v3(image.height, image.width, copies_count=copies)
         await self.set_image(
             image,
             wait_between_print_lines,
@@ -362,7 +369,7 @@ class PrinterClient:
             status = await self.get_print_status()
             if status["progress"] < 100:
                 started = True
-            if status["page"] >= 1 or (started and status["progress"] >= 100):
+            if status["page"] >= copies or (started and status["progress"] >= 100):
                 break
             if time.time() - start_time > 30:
                 _LOGGER.warning(
@@ -383,6 +390,7 @@ class PrinterClient:
         label_type: int = 1,
         density_min: int = 1,
         density_max: int = 5,
+        copies: int = 1,
     ):
         _LOGGER.debug("print_image_d110: %s", locals())
         await self.set_label_density(density, density_min, density_max)
@@ -390,7 +398,7 @@ class PrinterClient:
         await self.start_print()
         await self.start_page_print()
         await self.set_page_size_v2(image.height, image.width)
-        await self.set_quantity(1)
+        await self.set_quantity(copies)
         await self.set_image(
             image,
             wait_between_print_lines,
@@ -399,7 +407,7 @@ class PrinterClient:
         )
         await self.end_page_print()
         start_time = time.time()
-        while not await self.get_print_end():
+        while not await self.get_print_end(copies=copies):
             if time.time() - start_time > 5:
                 break
             await sleep(0.5)
@@ -415,17 +423,18 @@ class PrinterClient:
         label_type: int = 1,
         density_min: int = 1,
         density_max: int = 5,
+        copies: int = 1,
     ):
         _LOGGER.debug("print_image_d110m_v4: %s", locals())
         if not await self.set_label_density(density, density_min, density_max):
             raise RuntimeError(f"Could not set label density to {density}")
         if not await self.set_label_type(label_type):
             raise RuntimeError(f"Could not set label type to {label_type}")
-        if not await self.start_print_9b():
+        if not await self.start_print_9b(total_pages=1):
             raise RuntimeError("Could not start print")
         # https://github.com/MultiMote/niimbluelib/commit/20f3e42b1e457cad5ff3dfe3c9b86e602abc6f44#diff-c9930b13a15bc967ad905fd73c84d631918a2f5b701b9f95ff3fd50c9af37c43
         await self.heartbeat(await_for_response=False)
-        await self.set_page_size_9b(image.height, image.width)
+        await self.set_page_size_9b(image.height, image.width, copies_count=copies)
         await self.set_image(
             image,
             wait_between_print_lines,
@@ -436,7 +445,7 @@ class PrinterClient:
             raise RuntimeError("Page did not finish successfully")
         await sleep(1)
         start_time = time.time()
-        while not await self.get_print_end():
+        while not await self.get_print_end(copies=copies):
             if time.time() - start_time > 5:
                 break
             await sleep(0.1)
@@ -1006,11 +1015,21 @@ class PrinterClient:
         # use the maximum of both non-zero values, falling back to whichever is non-zero.
         active = [p for p in (progress1, progress2) if p > 0]
         progress = max(active) if active else 0
-        return {"page": page, "progress": progress}
+        status = {
+            "page": page,
+            "page_print_progress": progress1,
+            "page_feed_progress": progress2,
+            "progress": progress,
+        }
+        if self.on_progress is not None:
+            self.on_progress(status)
+        return status
 
-    async def get_print_end(self):
+    async def get_print_end(self, copies: int = 1):
         status = await self.get_print_status()
         _LOGGER.debug("Status: %s", status)
+        if status["page"] >= copies:
+            return True
         if status["progress"] < 100:
             return False
         return True

--- a/custom_components/niimbot/sensor.py
+++ b/custom_components/niimbot/sensor.py
@@ -38,6 +38,7 @@ SENSORS_MAPPING_TEMPLATE: dict[str, SensorEntityDescription] = {
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         name="Battery",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "last_error": SensorEntityDescription(
         key="last_error",
@@ -185,11 +186,20 @@ async def async_setup_entry(
     entities.extend(_add_rfid_entities())
     async_add_entities(entities)
 
-    # Model may be unknown until the first successful poll.
-    if not device.supports_label_rfid():
+    # Model / RFID capability may be unknown at setup (initial poll failed, or
+    # platforms load before the first successful device-type read). Keep listening
+    # until RFID entities are created, or the model is known to lack label RFID.
+    if "labels_remaining" not in created_keys:
 
         @callback
         def _on_coordinator_update() -> None:
+            if "labels_remaining" in created_keys:
+                unsub()
+                return
+            meta = device.get_model_meta()
+            if meta is not None and not device.supports_label_rfid():
+                unsub()
+                return
             new_entities = _add_rfid_entities()
             if new_entities:
                 async_add_entities(new_entities)
@@ -319,6 +329,7 @@ class NiimbotPrintDurationSensor(
     _attr_native_unit_of_measurement = UnitOfTime.SECONDS
     _attr_device_class = SensorDeviceClass.DURATION
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,
@@ -403,6 +414,7 @@ class NiimbotPrintProgressSensor(
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:progress-helper"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,

--- a/custom_components/niimbot/sensor.py
+++ b/custom_components/niimbot/sensor.py
@@ -45,6 +45,30 @@ SENSORS_MAPPING_TEMPLATE: dict[str, SensorEntityDescription] = {
         icon="mdi:alert-circle-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    "density": SensorEntityDescription(
+        key="density",
+        name="Print Density",
+        icon="mdi:printer-3d-nozzle",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    "printspeed": SensorEntityDescription(
+        key="printspeed",
+        name="Print Speed",
+        icon="mdi:speedometer",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    "labeltype": SensorEntityDescription(
+        key="labeltype",
+        name="Label Type",
+        icon="mdi:tag-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    "autoshutdowntime": SensorEntityDescription(
+        key="autoshutdowntime",
+        name="Auto Shutdown",
+        icon="mdi:timer-outline",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 }
 
 RFID_SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
@@ -132,11 +156,18 @@ async def async_setup_entry(
                     coordinator, coordinator.data, description, device
                 )
             )
+        elif key == "battery":
+            entities.append(
+                NiimbotBatterySensor(
+                    coordinator, coordinator.data, description, device
+                )
+            )
         else:
             entities.append(NiimbotSensor(coordinator, coordinator.data, description))
         created_keys.add(key)
 
     entities.append(NiimbotPrintDurationSensor(coordinator, coordinator.data, device))
+    entities.append(NiimbotPrintProgressSensor(coordinator, coordinator.data, device))
 
     def _add_rfid_entities() -> list[SensorEntity]:
         added: list[SensorEntity] = []
@@ -193,6 +224,31 @@ class NiimbotSensor(CoordinatorEntity[DataUpdateCoordinator[BLEData]], SensorEnt
             return self.coordinator.data.sensors[self.entity_description.key]
         except KeyError:
             return None
+
+
+class NiimbotBatterySensor(NiimbotSensor):
+    """Battery sensor with optional charge-bucket attribute."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[BLEData],
+        ble_data: BLEData,
+        entity_description: SensorEntityDescription,
+        device: NiimbotDevice,
+    ) -> None:
+        super().__init__(coordinator, ble_data, entity_description)
+        self._device = device
+
+    @property
+    def extra_state_attributes(self) -> dict | None:
+        bucket = self.coordinator.data.sensors.get("battery_bucket")
+        if bucket is None and self._device._info_battery_bucket is None:
+            return None
+        return {
+            "charge_bucket": bucket
+            if bucket is not None
+            else self._device._info_battery_bucket
+        }
 
 
 class NiimbotLastErrorSensor(NiimbotSensor):
@@ -333,5 +389,54 @@ class NiimbotPrintDurationSensor(
         seconds = int(duration % 60)
         return {
             "formatted": f"{minutes:02d}:{seconds:01d}",
+            "is_printing": self._device.is_printing,
+        }
+
+
+class NiimbotPrintProgressSensor(
+    CoordinatorEntity[DataUpdateCoordinator[BLEData]], SensorEntity
+):
+    """Live print progress percentage from GET_PRINT_STATUS polls."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Print Progress"
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:progress-helper"
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[BLEData],
+        ble_data: BLEData,
+        device: NiimbotDevice,
+    ) -> None:
+        super().__init__(coordinator)
+        self._device = device
+        name = f"{ble_data.name} {ble_data.identifier}"
+        self._attr_unique_id = f"{name}_print_progress"
+        self._attr_device_info = _device_info(ble_data)
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._device.callback_progress = self._handle_progress_update
+
+    async def async_will_remove_from_hass(self) -> None:
+        await super().async_will_remove_from_hass()
+        self._device.callback_progress = None
+
+    @callback
+    def _handle_progress_update(self) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> float:
+        return round(self._device.print_progress, 1)
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        return {
+            "page": self._device.print_page,
+            "page_print_progress": self._device.print_page_print_progress,
+            "page_feed_progress": self._device.print_page_feed_progress,
             "is_printing": self._device.is_printing,
         }

--- a/custom_components/niimbot/services.yaml
+++ b/custom_components/niimbot/services.yaml
@@ -61,6 +61,14 @@ print:
           min: 1
           max: 11
           step: 1
+    copies:
+      required: false
+      default: 1
+      selector:
+        number:
+          min: 1
+          max: 99
+          step: 1
     wait_between_print_lines:
       required: false
       default: 0.05
@@ -82,3 +90,8 @@ print:
       example: 'false'
       selector:
         boolean:
+
+refresh_info:
+  target:
+    device:
+      integration: niimbot

--- a/custom_components/niimbot/strings.json
+++ b/custom_components/niimbot/strings.json
@@ -74,6 +74,10 @@
           "name": "Label Type",
           "description": "Label type code (1=Gap, 2=Black, 3=Continuous, 4=Perforated, 5=Transparent, 6=PvcTag, 10=BlackMarkGap, 11=HeatShrinkTube). Default: 1."
         },
+        "copies": {
+          "name": "Copies",
+          "description": "Number of copies to print of the same label. Default: 1."
+        },
         "wait_between_print_lines": {
           "name": "Wait between print lines",
           "description": "Time to wait between each line sent to the printer."
@@ -87,6 +91,10 @@
           "description": "Instead of printing, return the image as a base64-encoded URL."
         }
       }
+    },
+    "refresh_info": {
+      "name": "Refresh Printer Info",
+      "description": "Re-read cached printer settings (density, speed, label type, auto shutdown, battery bucket)."
     }
   }
 }

--- a/custom_components/niimbot/translations/en.json
+++ b/custom_components/niimbot/translations/en.json
@@ -69,6 +69,10 @@
                     "name": "Label Type",
                     "description": "Label type code (1=Gap, 2=Black, 3=Continuous, 4=Perforated, 5=Transparent, 6=PvcTag, 10=BlackMarkGap, 11=HeatShrinkTube). Default: 1."
                 },
+                "copies": {
+                    "name": "Copies",
+                    "description": "Number of copies to print of the same label. Default: 1."
+                },
                 "wait_between_print_lines": {
                     "name": "Wait between print lines",
                     "description": "Time to wait between each line sent to the printer."
@@ -82,6 +86,10 @@
                     "description": "Instead of printing, return the image as a base64-encoded URL."
                 }
             }
+        },
+        "refresh_info": {
+            "name": "Refresh Printer Info",
+            "description": "Re-read cached printer settings (density, speed, label type, auto shutdown, battery bucket)."
         }
     }
 }

--- a/custom_components/niimbot/translations/ko.json
+++ b/custom_components/niimbot/translations/ko.json
@@ -69,6 +69,10 @@
                     "name": "라벨 타입",
                     "description": "라벨 타입 코드 (1=Gap, 2=Black, 3=Continuous, 4=Perforated, 5=Transparent, 6=PvcTag, 10=BlackMarkGap, 11=HeatShrinkTube). 기본값: 1."
                 },
+                "copies": {
+                    "name": "매수",
+                    "description": "같은 라벨을 인쇄할 매수. 기본값: 1."
+                },
                 "wait_between_print_lines": {
                     "name": "라인 간 대기 시간",
                     "description": "프린터로 전송되는 각 라인 사이의 대기 시간입니다."
@@ -82,6 +86,10 @@
                     "description": "인쇄하는 대신 이미지를 base64 인코딩 URL로 반환합니다."
                 }
             }
+        },
+        "refresh_info": {
+            "name": "프린터 정보 새로고침",
+            "description": "캐시된 프린터 설정(농도, 속도, 라벨 타입, 자동 종료, 배터리 버킷)을 다시 읽습니다."
         }
     }
 }

--- a/tests/test_protocol_phase1.py
+++ b/tests/test_protocol_phase1.py
@@ -1,6 +1,7 @@
 """Phase 1 protocol correctness tests."""
 
 import asyncio
+import struct
 
 import pytest
 
@@ -239,3 +240,27 @@ def test_battery_percentage_b1_pro_advanced2_is_bucket():
     # Advanced2 always uses the 0–4 bucket, even on B1 Pro.
     assert _battery_percentage(4, "B1_PRO", variant="advanced2") == 100
     assert _battery_percentage(2, "B1_PRO", variant="advanced2") == 50
+
+
+def test_get_print_status_keeps_separate_progress_fields():
+    async def _test():
+        # page=1, print=80, feed=40
+        payload = struct.pack(">HBB", 1, 80, 40)
+        transport = FakeTransport(
+            [NiimbotPacket(RequestCodeEnum.GET_PRINT_STATUS + 16, payload)]
+        )
+        client = PrinterClient(transport=transport)
+        seen = {}
+
+        def on_progress(status):
+            seen.update(status)
+
+        client.on_progress = on_progress
+        status = await client.get_print_status()
+        assert status["page"] == 1
+        assert status["page_print_progress"] == 80
+        assert status["page_feed_progress"] == 40
+        assert status["progress"] == 80
+        assert seen["progress"] == 80
+
+    run(_test())


### PR DESCRIPTION
## Summary
- Add `copies` to `niimbot.print` (B1 uses SetPageSize copies; older gens use PrintQuantity).
- Surface live Print Progress from `GET_PRINT_STATUS`, keeping page/print/feed fields separate as attributes.
- Cache PrinterInfo settings (density/speed/label type/auto shutdown/battery bucket) once, with `niimbot.refresh_info` to force a re-read; heartbeat battery falls back to the cached bucket.
- Reuse one `PrinterClient` + notify subscription when `keep_connection` is enabled.

## Test plan
- [x] `pytest tests/` (25 passed locally)
- [ ] B1: print with `copies: 2` and confirm two labels
- [ ] B1: watch Print Progress during a print
- [ ] Call `niimbot.refresh_info` and confirm density/label type sensors update
- [ ] With `keep_connection` on, confirm poll + print no longer re-subscribe every time


Made with [Cursor](https://cursor.com)