### PR TITLE
Add Auto Shutdown select and Connection Sound switch

### DIFF
--- a/custom_components/niimbot/__init__.py
+++ b/custom_components/niimbot/__init__.py
@@ -41,7 +41,13 @@ from .const import (
     ImageAndBLEData,
 )
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.IMAGE, Platform.BINARY_SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.IMAGE,
+    Platform.BINARY_SENSOR,
+    Platform.SELECT,
+    Platform.SWITCH,
+]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,7 +56,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Niimbot BLE device from a config entry."""
     hass.data.setdefault(DOMAIN, {})
     address = entry.unique_id
-    use_sound = entry.options.get(CONF_USE_SOUND, entry.data.get(CONF_USE_SOUND))
+    # Legacy option — only seeds the Connection Sound switch until get_sound works.
+    connection_sound_seed = entry.options.get(
+        CONF_USE_SOUND, entry.data.get(CONF_USE_SOUND, True)
+    )
     scan_interval = float(
         entry.options.get(
             CONF_SCAN_INTERVAL, entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
@@ -98,7 +107,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             address,
         )
 
-    niimbot = NiimbotDevice(address, use_sound, keep_connection)
+    niimbot = NiimbotDevice(
+        address,
+        keep_connection=keep_connection,
+        connection_sound_seed=connection_sound_seed,
+    )
 
     async def _async_update_method() -> BLEData:
         """Get data from Niimbot BLE."""
@@ -201,6 +214,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 else 1,
                 copies=int(service.data["copies"]) if "copies" in service.data else 1,
             )
+            # Push post-print RFID / heartbeat updates into entities immediately.
+            coordinator.async_set_updated_data(niimbot.ble_data)
             result["image"] = image_data
             return result
         except (PrinterError, RuntimeError, ValueError) as e:

--- a/custom_components/niimbot/config_flow.py
+++ b/custom_components/niimbot/config_flow.py
@@ -25,7 +25,6 @@ from homeassistant.helpers.selector import (
 )
 
 from .const import (
-    CONF_USE_SOUND,
     CONF_WAIT_BETWEEN_EACH_PRINT_LINE,
     CONF_CONFIRM_EVERY_NTH_PRINT_LINE,
     CONF_KEEP_CONNECTION,
@@ -41,7 +40,6 @@ _LOGGER = logging.getLogger(__name__)
 
 
 OPTIONS_SCHEMA = {
-    vol.Required(CONF_USE_SOUND, default=True): bool,
     vol.Required(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): NumberSelector(
         NumberSelectorConfig(
             min=10,

--- a/custom_components/niimbot/niimprint/model.py
+++ b/custom_components/niimbot/niimprint/model.py
@@ -710,6 +710,28 @@ def consumable_type_name(type_code: int | None) -> str | None:
     return _LABEL_TYPE_NAMES.get(type_code, f"Unknown({type_code})")
 
 
+# PrinterInfo AutoShutdownTime is an index, not minutes (model-dependent).
+AUTO_SHUTDOWN_OPTIONS: dict[int, str] = {
+    1: "15 min",
+    2: "30 min",
+    3: "45–60 min",
+    4: "60 min / never",
+}
+
+
+def auto_shutdown_label(index: int | None) -> str | None:
+    if index is None:
+        return None
+    return AUTO_SHUTDOWN_OPTIONS.get(int(index), f"Index {index}")
+
+
+def auto_shutdown_index(label: str) -> int | None:
+    for index, name in AUTO_SHUTDOWN_OPTIONS.items():
+        if name == label:
+            return index
+    return None
+
+
 def label_type_code(label_type: LabelType) -> int:
     return _LABEL_TYPE_CODES[label_type]
 

--- a/custom_components/niimbot/niimprint/parser.py
+++ b/custom_components/niimbot/niimprint/parser.py
@@ -78,13 +78,15 @@ class BLEData:
 class NiimbotDevice:
     """Data for Niimbot BLE sensors."""
 
-    def __init__(self, address, use_sound, keep_connection=False):
+    def __init__(self, address, keep_connection=False, connection_sound_seed: bool | None = True):
         self.address = address
-        self.use_sound = use_sound
         self.keep_connection = keep_connection
         self.lock = asyncio.Lock()
-        self.set_sound = None
         self.model = None
+        # Seed from legacy use_sound config until the printer reports its state.
+        self.connection_sound: bool | None = (
+            bool(connection_sound_seed) if connection_sound_seed is not None else True
+        )
         self.ble_data = BLEData(
             address=address,
             name="Niimbot",
@@ -99,8 +101,8 @@ class NiimbotDevice:
                 "density": None,
                 "printspeed": None,
                 "labeltype": None,
-                "autoshutdowntime": None,
                 "print_progress": 0.0,
+                "connection_sound": self.connection_sound,
             }
         )
         self.client = None
@@ -347,12 +349,47 @@ class NiimbotDevice:
             )
         if autoshutdown is not None:
             self.ble_data.autoshutdowntime = int(autoshutdown)
-            self.ble_data.sensors["autoshutdowntime"] = self.ble_data.autoshutdowntime
         if battery_bucket is not None:
             self._info_battery_bucket = int(battery_bucket)
             self.ble_data.sensors["battery_bucket"] = self._info_battery_bucket
 
         self._info_loaded = True
+
+    def _apply_connection_sound(self, on: bool) -> None:
+        self.connection_sound = on
+        self.ble_data.sensors["connection_sound"] = on
+
+    async def set_auto_shutdown(self, ble_device: BLEDevice, index: int) -> BLEData:
+        """Write AutoShutdownTime and update the local cache."""
+        async with self.lock:
+            printer = await self._ensure_printer(ble_device)
+            try:
+                ok = await printer.set_auto_shutdown_time(index)
+                if not ok:
+                    raise RuntimeError(
+                        f"Printer rejected auto shutdown index {index}"
+                    )
+                self.ble_data.autoshutdowntime = int(index)
+            finally:
+                await self._release_printer()
+            return self.ble_data
+
+    async def set_connection_sound(
+        self, ble_device: BLEDevice, on: bool
+    ) -> BLEData:
+        """Write Bluetooth connection beep and update the local cache."""
+        async with self.lock:
+            printer = await self._ensure_printer(ble_device)
+            try:
+                ok = await printer.set_sound(
+                    SoundEnum.BluetoothConnectionSound, on
+                )
+                if not ok:
+                    raise RuntimeError("Printer rejected connection sound setting")
+                self._apply_connection_sound(on)
+            finally:
+                await self._release_printer()
+            return self.ble_data
 
     async def update_device(self, ble_device: BLEDevice) -> BLEData:
         """Connects to the device through BLE and retrieves relevant data"""
@@ -385,12 +422,14 @@ class NiimbotDevice:
                             meta["model"].name if meta else str(device_type)
                         )
                         self.model = self.ble_data.model
-                if not self.set_sound:
-                    self.set_sound = await printer.set_sound(
-                        SoundEnum.BluetoothConnectionSound, self.use_sound
-                    )
 
                 await self._load_printer_info(printer)
+
+                sound = await printer.get_sound(SoundEnum.BluetoothConnectionSound)
+                if sound is not None:
+                    self._apply_connection_sound(sound)
+                else:
+                    self.ble_data.sensors["connection_sound"] = self.connection_sound
 
                 heartbeat = await printer.heartbeat(model_id=self.ble_data.devicetype)
                 if printer.heartbeat_payload is not None:
@@ -429,7 +468,9 @@ class NiimbotDevice:
             _LOGGER.debug("Obtained BLEData: %s", self.ble_data)
             return self.ble_data
 
-    async def _maybe_read_rfid(self, printer: PrinterClient, heartbeat: dict) -> None:
+    async def _maybe_read_rfid(
+        self, printer: PrinterClient, heartbeat: dict, *, force: bool = False
+    ) -> None:
         """Read label RFID when the model supports it."""
         if not self.supports_label_rfid():
             return
@@ -443,9 +484,11 @@ class NiimbotDevice:
         # the round-trip when the printer explicitly reports unreadiness as 0 —
         # and even then fall through if we have never successfully read a tag,
         # because some models (observed on B1) leave the flag at 0 with stock
-        # loaded.
+        # loaded. After a print, force=True so used_len is re-read even when the
+        # readiness flag stays 0.
         if (
-            rfid_ready is not None
+            not force
+            and rfid_ready is not None
             and not rfid_ready
             and self._last_rfid_uuid is not None
         ):
@@ -459,6 +502,28 @@ class NiimbotDevice:
             return
 
         self._apply_rfid_info(info)
+
+    async def _refresh_after_print(self, printer: PrinterClient) -> None:
+        """Re-read heartbeat + RFID after a job — used_len is written during print."""
+        try:
+            # Give the printer a moment to finish writing the tag.
+            await asyncio.sleep(0.5)
+            heartbeat = await printer.heartbeat(model_id=self.ble_data.devicetype)
+            self.ble_data.sensors["closingstate"] = heartbeat["closingstate"]
+            self.ble_data.sensors["paperstate"] = heartbeat["paperstate"]
+            self.ble_data.sensors["rfidreadstate"] = heartbeat["rfidreadstate"]
+            battery = _battery_percentage(
+                heartbeat["powerlevel"],
+                self.ble_data.model,
+                variant=heartbeat.get("variant"),
+            )
+            if battery is None and self._info_battery_bucket is not None:
+                battery = round(float(self._info_battery_bucket) * 25.0)
+            if battery is not None:
+                self.ble_data.sensors["battery"] = battery
+            await self._maybe_read_rfid(printer, heartbeat, force=True)
+        except Exception as err:
+            _LOGGER.debug("Post-print status refresh failed: %s", err)
 
     async def print_image(
         self,
@@ -521,6 +586,9 @@ class NiimbotDevice:
                 if self.print_progress < 100:
                     self.print_progress = 100.0
                     self.ble_data.sensors["print_progress"] = 100.0
+                # Printer writes used_len back to the RFID tag during the job;
+                # re-read before disconnecting so remaining/usage sensors update.
+                await self._refresh_after_print(printer)
             finally:
                 if self._printer is not None:
                     self._printer.on_progress = None

--- a/custom_components/niimbot/niimprint/printer.py
+++ b/custom_components/niimbot/niimprint/printer.py
@@ -69,11 +69,17 @@ class RequestCodeEnum(enum.IntEnum):
     PRINT_BITMAP_ROW = 133  # 0x85
     PRINT_CLEAR = 32  # 0x20
     SET_SOUND = 88  # 0x58
+    SET_AUTO_SHUTDOWN_TIME = 39  # 0x27
 
 
 class SoundEnum(enum.IntEnum):
     BluetoothConnectionSound = 1
     PowerSound = 2
+
+
+class SoundSettingsType(enum.IntEnum):
+    SetSound = 1
+    GetSoundState = 2
 
 
 class PrinterErrorCodeEnum(enum.IntEnum):
@@ -965,10 +971,41 @@ class PrinterClient:
     async def set_sound(self, key, on: bool):
         packet = await self._transceive(
             RequestCodeEnum.SET_SOUND,
-            struct.pack(">BBB", 0x01, key, 0x01 if on else 0x00),
+            struct.pack(
+                ">BBB", SoundSettingsType.SetSound, key, 0x01 if on else 0x00
+            ),
             16,
         )
         return bool(packet.data[0])
+
+    async def get_sound(self, key) -> bool | None:
+        """Read a sound setting. Returns None when unsupported or timed out."""
+        try:
+            packet = await self._transceive(
+                RequestCodeEnum.SET_SOUND,
+                struct.pack(">BBB", SoundSettingsType.GetSoundState, key, 0x01),
+                16,
+            )
+        except (PrinterTimeout, PrinterCommandUnsupported) as err:
+            _LOGGER.debug("get_sound(%s) unavailable: %s", key, err)
+            return None
+        if len(packet.data) < 3:
+            return None
+        return bool(packet.data[2])
+
+    async def set_auto_shutdown_time(self, index: int) -> bool:
+        if not 1 <= index <= 4:
+            raise ValueError(f"Auto shutdown index {index} out of range 1-4")
+        try:
+            packet = await self._transceive(
+                RequestCodeEnum.SET_AUTO_SHUTDOWN_TIME,
+                bytes((index,)),
+                16,
+            )
+        except (PrinterTimeout, PrinterCommandUnsupported) as err:
+            _LOGGER.debug("set_auto_shutdown_time(%s) failed: %s", index, err)
+            return False
+        return bool(packet.data[0]) if packet.data else False
 
     async def get_print_status(self, await_for_response=True):
         _LOGGER.debug("Get print status")

--- a/custom_components/niimbot/select.py
+++ b/custom_components/niimbot/select.py
@@ -1,0 +1,97 @@
+"""Select entities for Niimbot printer settings."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant import config_entries
+from homeassistant.components.select import SelectEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+from homeassistant.components import bluetooth
+
+from .const import DOMAIN
+from .niimprint import BLEData, NiimbotDevice
+from .niimprint.model import (
+    AUTO_SHUTDOWN_OPTIONS,
+    auto_shutdown_index,
+    auto_shutdown_label,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Niimbot select entities."""
+    coordinator: DataUpdateCoordinator[BLEData] = hass.data[DOMAIN][entry.entry_id][
+        "coordinator"
+    ]
+    device: NiimbotDevice = hass.data[DOMAIN][entry.entry_id]["device"]
+    async_add_entities(
+        [NiimbotAutoShutdownSelect(coordinator, coordinator.data, device)]
+    )
+
+
+class NiimbotAutoShutdownSelect(
+    CoordinatorEntity[DataUpdateCoordinator[BLEData]], SelectEntity
+):
+    """Select for printer auto-shutdown time."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Auto Shutdown"
+    _attr_icon = "mdi:timer-outline"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_options = list(AUTO_SHUTDOWN_OPTIONS.values())
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[BLEData],
+        ble_data: BLEData,
+        device: NiimbotDevice,
+    ) -> None:
+        super().__init__(coordinator)
+        self._device = device
+        name = f"{ble_data.name} {ble_data.identifier}"
+        self._attr_unique_id = f"{name}_auto_shutdown"
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, ble_data.address)},
+            name=name,
+            manufacturer="Niimbot",
+            model=ble_data.model,
+            hw_version=ble_data.hw_version,
+            sw_version=ble_data.sw_version,
+            serial_number=ble_data.serial_number,
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        return auto_shutdown_label(self._device.ble_data.autoshutdowntime)
+
+    async def async_select_option(self, option: str) -> None:
+        index = auto_shutdown_index(option)
+        if index is None:
+            raise HomeAssistantError(f"Unknown auto shutdown option: {option}")
+        ble_device = bluetooth.async_ble_device_from_address(
+            self.hass, self._device.address
+        )
+        if ble_device is None:
+            raise HomeAssistantError(
+                f"Could not find printer with address {self._device.address}"
+            )
+        try:
+            data = await self._device.set_auto_shutdown(ble_device, index)
+        except Exception as err:
+            raise HomeAssistantError(f"Failed to set auto shutdown: {err}") from err
+        self.coordinator.async_set_updated_data(data)

--- a/custom_components/niimbot/sensor.py
+++ b/custom_components/niimbot/sensor.py
@@ -64,12 +64,6 @@ SENSORS_MAPPING_TEMPLATE: dict[str, SensorEntityDescription] = {
         icon="mdi:tag-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    "autoshutdowntime": SensorEntityDescription(
-        key="autoshutdowntime",
-        name="Auto Shutdown",
-        icon="mdi:timer-outline",
-        entity_category=EntityCategory.DIAGNOSTIC,
-    ),
 }
 
 RFID_SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {

--- a/custom_components/niimbot/strings.json
+++ b/custom_components/niimbot/strings.json
@@ -6,7 +6,6 @@
         "description": "[%key:component::bluetooth::config::step::user::description%]",
         "data": {
           "address": "[%key:component::bluetooth::config::step::user::data::address%]",
-          "use_sound": "Use Sound",
           "scan_interval": "Scan Interval",
           "wait_between_each_print_line": "Wait Between Each Print Line",
           "confirm_every_nth_print_line": "Confirm Every Nth Print Line",
@@ -16,7 +15,6 @@
       "bluetooth_confirm": {
         "description": "[%key:component::bluetooth::config::step::bluetooth_confirm::description%]",
         "data": {
-          "use_sound": "Use Sound",
           "scan_interval": "Scan Interval",
           "wait_between_each_print_line": "Wait Between Each Print Line",
           "confirm_every_nth_print_line": "Confirm Every Nth Print Line",
@@ -36,7 +34,6 @@
     "step": {
       "init": {
         "data": {
-          "use_sound": "Use Sound",
           "scan_interval": "Scan Interval",
           "wait_between_each_print_line": "Wait Between Each Print Line",
           "confirm_every_nth_print_line": "Confirm Every Nth Print Line",

--- a/custom_components/niimbot/switch.py
+++ b/custom_components/niimbot/switch.py
@@ -1,0 +1,99 @@
+"""Switch entities for Niimbot printer settings."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant import config_entries
+from homeassistant.components import bluetooth
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .const import DOMAIN
+from .niimprint import BLEData, NiimbotDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Niimbot switch entities."""
+    coordinator: DataUpdateCoordinator[BLEData] = hass.data[DOMAIN][entry.entry_id][
+        "coordinator"
+    ]
+    device: NiimbotDevice = hass.data[DOMAIN][entry.entry_id]["device"]
+    async_add_entities(
+        [NiimbotConnectionSoundSwitch(coordinator, coordinator.data, device)]
+    )
+
+
+class NiimbotConnectionSoundSwitch(
+    CoordinatorEntity[DataUpdateCoordinator[BLEData]], SwitchEntity
+):
+    """Switch for Bluetooth connection beep."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Connection Sound"
+    _attr_icon = "mdi:volume-high"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[BLEData],
+        ble_data: BLEData,
+        device: NiimbotDevice,
+    ) -> None:
+        super().__init__(coordinator)
+        self._device = device
+        name = f"{ble_data.name} {ble_data.identifier}"
+        self._attr_unique_id = f"{name}_connection_sound"
+        self._attr_device_info = DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, ble_data.address)},
+            name=name,
+            manufacturer="Niimbot",
+            model=ble_data.model,
+            hw_version=ble_data.hw_version,
+            sw_version=ble_data.sw_version,
+            serial_number=ble_data.serial_number,
+        )
+
+    @property
+    def is_on(self) -> bool:
+        value = self.coordinator.data.sensors.get("connection_sound")
+        if value is None:
+            return bool(self._device.connection_sound)
+        return bool(value)
+
+    async def async_turn_on(self, **kwargs) -> None:
+        await self._set_sound(True)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        await self._set_sound(False)
+
+    async def _set_sound(self, on: bool) -> None:
+        ble_device = bluetooth.async_ble_device_from_address(
+            self.hass, self._device.address
+        )
+        if ble_device is None:
+            raise HomeAssistantError(
+                f"Could not find printer with address {self._device.address}"
+            )
+        try:
+            data = await self._device.set_connection_sound(ble_device, on)
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Failed to set connection sound: {err}"
+            ) from err
+        self.coordinator.async_set_updated_data(data)

--- a/custom_components/niimbot/translations/en.json
+++ b/custom_components/niimbot/translations/en.json
@@ -15,7 +15,6 @@
             "user": {
                 "data": {
                     "address": "Device",
-                    "use_sound": "Use Sound",
                     "scan_interval": "Scan Interval",
                     "wait_between_each_print_line": "Wait time between print lines",
                     "confirm_every_nth_print_line": "How often to confirm reception of print lines",
@@ -30,7 +29,6 @@
         "step": {
             "init": {
                 "data": {
-                    "use_sound": "Use Sound",
                     "scan_interval": "Scan Interval",
                     "wait_between_each_print_line": "Wait time between print lines",
                     "confirm_every_nth_print_line": "How often to confirm reception of print lines",

--- a/custom_components/niimbot/translations/ko.json
+++ b/custom_components/niimbot/translations/ko.json
@@ -15,7 +15,6 @@
             "user": {
                 "data": {
                     "address": "기기",
-                    "use_sound": "소리 사용",
                     "scan_interval": "스캔 간격",
                     "wait_between_each_print_line": "인쇄 라인 간 대기 시간",
                     "confirm_every_nth_print_line": "인쇄 라인 수신 확인 간격",
@@ -30,7 +29,6 @@
         "step": {
             "init": {
                 "data": {
-                    "use_sound": "소리 사용",
                     "scan_interval": "스캔 간격",
                     "wait_between_each_print_line": "인쇄 라인 간 대기 시간",
                     "confirm_every_nth_print_line": "인쇄 라인 수신 확인 간격",

--- a/docs/device-info.md
+++ b/docs/device-info.md
@@ -133,7 +133,7 @@ An index, not minutes. The mapping is model-dependent:
 | 3 | 45 or 60 min |
 | 4 | 60 min or never |
 
-Write it back with `SetAutoShutdownTime` (`0x27`). **(not implemented here)**
+Write it back with `SetAutoShutdownTime` (`0x27`). Exposed as the Auto Shutdown select entity.
 
 ## 4. Heartbeat (`0xDC`)
 
@@ -256,7 +256,8 @@ One command does both get and set. Payload is always 3 bytes:
 | `0x02` | Power on/off beep |
 
 For a set, `value` is `0` or `1`. For a get, send `value = 1` and read the state from `data[2]` of the
-`0x68` response. This integration implements set only.
+`0x68` response. This integration implements get and set for the Bluetooth connection beep via the
+Connection Sound switch.
 
 ## 7. Other state commands
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -169,9 +169,9 @@ sent before the page was started — not only for physical faults.
 | --- | --- | --- | --- | --- |
 | `0x21` | SetDensity | `0x31` | `u8` | Range is per model, see [devices.md](devices.md) |
 | `0x23` | SetLabelType | `0x33` | `u8` | Label type, section 6 |
-| `0x27` | SetAutoShutdownTime | `0x37` | `u8` 1–4 | **(not implemented here)** |
+| `0x27` | SetAutoShutdownTime | `0x37` | `u8` 1–4 | Auto Shutdown select entity |
 | `0x28` | PrinterReset | `0x38` | `01` | Resets settings such as sound. **(not implemented here)** |
-| `0x58` | SoundSettings | `0x68` | `category`, `item`, `value` | Get and set share one command |
+| `0x58` | SoundSettings | `0x68` | `category`, `item`, `value` | Connection Sound switch (get/set) |
 | `0x59` | CalibrateHeight | `0x69` | `01` | **(not implemented here)** |
 | `0x8E` | LabelPositioningCalibration | `0x8F` | `u8` | Feeds ~15 cm on B1 for values 1–2. **(not implemented here)** |
 

--- a/tests/test_protocol_phase1.py
+++ b/tests/test_protocol_phase1.py
@@ -235,6 +235,27 @@ def test_get_info_unsupported_key_returns_none():
     run(_test())
 
 
+def test_get_sound_reads_state_byte():
+    async def _test():
+        # Response 0x68 with category/item/value — value at data[2]
+        transport = FakeTransport([NiimbotPacket(0x68, bytes((0x02, 0x01, 0x01)))])
+        client = PrinterClient(transport=transport)
+        assert await client.get_sound(1) is True
+
+    run(_test())
+
+
+def test_set_auto_shutdown_time_success():
+    async def _test():
+        transport = FakeTransport([NiimbotPacket(0x37, b"\x01")])
+        client = PrinterClient(transport=transport)
+        assert await client.set_auto_shutdown_time(3) is True
+        assert transport.written_packets[0].type == 0x27
+        assert transport.written_packets[0].data == b"\x03"
+
+    run(_test())
+
+
 def test_battery_percentage_none():
     assert _battery_percentage(None, "B1") is None
 


### PR DESCRIPTION
## Summary
- Add CONFIG **Auto Shutdown** select (`SetAutoShutdownTime` 0x27) and **Connection Sound** switch (sound get/set)
- Remove `use_sound` from config/options UI (legacy value only seeds the switch until `get_sound` succeeds)
- Remove duplicate Auto Shutdown diagnostic sensor; refresh RFID counters after a successful print
- Document protocol status and add unit coverage for sound/auto-shutdown packets

## Test plan
- [ ] Reload integration; confirm Auto Shutdown select and Connection Sound switch appear under device Configuration
- [ ] Change Auto Shutdown and verify with `refresh_info` / next poll that PrinterInfo key 7 matches
- [ ] Toggle Connection Sound and confirm get_sound / reconnect beep behavior on B1
- [ ] Print one label and confirm Labels Remaining / Used update without waiting for scan interval
- [ ] Confirm options flow no longer shows Use Sound


Made with [Cursor](https://cursor.com)