### PR TITLE
Add entity translations and binary sensor state labels

### DIFF
--- a/custom_components/niimbot/binary_sensor.py
+++ b/custom_components/niimbot/binary_sensor.py
@@ -29,13 +29,13 @@ _LOGGER = logging.getLogger(__name__)
 @dataclasses.dataclass(frozen=True)
 class NiimbotBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Binary sensor description with inversion flag."""
+
     inverted: bool = False
 
 
 BINARY_SENSORS: list[NiimbotBinarySensorEntityDescription] = [
     NiimbotBinarySensorEntityDescription(
         key="closingstate",
-        name="Lid",
         device_class=BinarySensorDeviceClass.DOOR,
         icon="mdi:printer-alert",
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -43,7 +43,7 @@ BINARY_SENSORS: list[NiimbotBinarySensorEntityDescription] = [
     ),
     NiimbotBinarySensorEntityDescription(
         key="paperstate",
-        name="Paper Loaded",
+        translation_key="paper",
         icon="mdi:label-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
         # Protocol (Advanced1/2): paperstate == 0 means inserted. Confirmed on B1
@@ -52,7 +52,7 @@ BINARY_SENSORS: list[NiimbotBinarySensorEntityDescription] = [
     ),
     NiimbotBinarySensorEntityDescription(
         key="rfidreadstate",
-        name="RFID Readable",
+        translation_key="rfid",
         icon="mdi:nfc-variant",
         entity_category=EntityCategory.DIAGNOSTIC,
         # rfidreadstate != 0 means readable
@@ -146,7 +146,6 @@ class NiimbotConnectionBinarySensor(
         name = f"{ble_data.name} {ble_data.identifier}"
 
         self._attr_unique_id = f"{name}_connection"
-        self._attr_name = "Connection"
 
         self._id = ble_data.address
         self._attr_device_info = DeviceInfo(

--- a/custom_components/niimbot/image.py
+++ b/custom_components/niimbot/image.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
     image_coordinator = hass.data[DOMAIN][config_entry.entry_id]["image_coordinator"]
     desc = ImageEntityDescription(
         key="last_label_made",
-        name="Last Label Made",
+        translation_key="last_label_made",
     )
     async_add_entities(
         [

--- a/custom_components/niimbot/niimprint/model.py
+++ b/custom_components/niimbot/niimprint/model.py
@@ -711,25 +711,32 @@ def consumable_type_name(type_code: int | None) -> str | None:
 
 
 # PrinterInfo AutoShutdownTime is an index, not minutes (model-dependent).
+# Option values are stable translation keys (see entity.select.auto_shutdown.state).
 AUTO_SHUTDOWN_OPTIONS: dict[int, str] = {
-    1: "15 min",
-    2: "30 min",
-    3: "45–60 min",
-    4: "60 min / never",
+    1: "15_min",
+    2: "30_min",
+    3: "45_60_min",
+    4: "60_min_never",
 }
 
 
-def auto_shutdown_label(index: int | None) -> str | None:
+def auto_shutdown_option(index: int | None) -> str | None:
+    """Return the select option key for a PrinterInfo auto-shutdown index."""
     if index is None:
         return None
-    return AUTO_SHUTDOWN_OPTIONS.get(int(index), f"Index {index}")
+    return AUTO_SHUTDOWN_OPTIONS.get(int(index))
 
 
-def auto_shutdown_index(label: str) -> int | None:
-    for index, name in AUTO_SHUTDOWN_OPTIONS.items():
-        if name == label:
+def auto_shutdown_index(option: str) -> int | None:
+    for index, key in AUTO_SHUTDOWN_OPTIONS.items():
+        if key == option:
             return index
     return None
+
+
+# Back-compat alias used by older call sites.
+def auto_shutdown_label(index: int | None) -> str | None:
+    return auto_shutdown_option(index)
 
 
 def label_type_code(label_type: LabelType) -> int:

--- a/custom_components/niimbot/select.py
+++ b/custom_components/niimbot/select.py
@@ -23,7 +23,7 @@ from .niimprint import BLEData, NiimbotDevice
 from .niimprint.model import (
     AUTO_SHUTDOWN_OPTIONS,
     auto_shutdown_index,
-    auto_shutdown_label,
+    auto_shutdown_option,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ class NiimbotAutoShutdownSelect(
     """Select for printer auto-shutdown time."""
 
     _attr_has_entity_name = True
-    _attr_name = "Auto Shutdown"
+    _attr_translation_key = "auto_shutdown"
     _attr_icon = "mdi:timer-outline"
     _attr_entity_category = EntityCategory.CONFIG
     _attr_options = list(AUTO_SHUTDOWN_OPTIONS.values())
@@ -77,7 +77,7 @@ class NiimbotAutoShutdownSelect(
 
     @property
     def current_option(self) -> str | None:
-        return auto_shutdown_label(self._device.ble_data.autoshutdowntime)
+        return auto_shutdown_option(self._device.ble_data.autoshutdowntime)
 
     async def async_select_option(self, option: str) -> None:
         index = auto_shutdown_index(option)

--- a/custom_components/niimbot/sensor.py
+++ b/custom_components/niimbot/sensor.py
@@ -37,30 +37,29 @@ SENSORS_MAPPING_TEMPLATE: dict[str, SensorEntityDescription] = {
         key="battery",
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
-        name="Battery",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "last_error": SensorEntityDescription(
         key="last_error",
-        name="Last Error",
+        translation_key="last_error",
         icon="mdi:alert-circle-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "density": SensorEntityDescription(
         key="density",
-        name="Print Density",
+        translation_key="density",
         icon="mdi:printer-3d-nozzle",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "printspeed": SensorEntityDescription(
         key="printspeed",
-        name="Print Speed",
+        translation_key="printspeed",
         icon="mdi:speedometer",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "labeltype": SensorEntityDescription(
         key="labeltype",
-        name="Label Type",
+        translation_key="labeltype",
         icon="mdi:tag-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
@@ -69,45 +68,45 @@ SENSORS_MAPPING_TEMPLATE: dict[str, SensorEntityDescription] = {
 RFID_SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
     "labels_remaining": SensorEntityDescription(
         key="labels_remaining",
-        name="Labels Remaining",
+        translation_key="labels_remaining",
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:label-multiple",
     ),
     "labels_used": SensorEntityDescription(
         key="labels_used",
-        name="Labels Used",
+        translation_key="labels_used",
         state_class=SensorStateClass.TOTAL_INCREASING,
         icon="mdi:label-off",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "labels_total": SensorEntityDescription(
         key="labels_total",
-        name="Labels Total",
+        translation_key="labels_total",
         icon="mdi:label",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "consumable_usage": SensorEntityDescription(
         key="consumable_usage",
-        name="Consumable Usage",
+        translation_key="consumable_usage",
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:percent",
     ),
     "label_sku": SensorEntityDescription(
         key="label_sku",
-        name="Label SKU",
+        translation_key="label_sku",
         icon="mdi:barcode",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "consumable_type": SensorEntityDescription(
         key="consumable_type",
-        name="Consumable Type",
+        translation_key="consumable_type",
         icon="mdi:tag-text",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "tag_uuid": SensorEntityDescription(
         key="tag_uuid",
-        name="Tag UUID",
+        translation_key="tag_uuid",
         icon="mdi:identifier",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -319,7 +318,7 @@ class NiimbotPrintDurationSensor(
     """Niimbot print duration sensor."""
 
     _attr_has_entity_name = True
-    _attr_name = "Print Duration"
+    _attr_translation_key = "print_duration"
     _attr_native_unit_of_measurement = UnitOfTime.SECONDS
     _attr_device_class = SensorDeviceClass.DURATION
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -404,7 +403,7 @@ class NiimbotPrintProgressSensor(
     """Live print progress percentage from GET_PRINT_STATUS polls."""
 
     _attr_has_entity_name = True
-    _attr_name = "Print Progress"
+    _attr_translation_key = "print_progress"
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:progress-helper"

--- a/custom_components/niimbot/strings.json
+++ b/custom_components/niimbot/strings.json
@@ -93,5 +93,89 @@
       "name": "Refresh Printer Info",
       "description": "Re-read cached printer settings (density, speed, label type, auto shutdown, battery bucket)."
     }
+  },
+    "entity": {
+    "binary_sensor": {
+      "paper": {
+        "name": "Paper",
+        "state": {
+          "on": "Loaded",
+          "off": "Empty"
+        }
+      },
+      "rfid": {
+        "name": "RFID",
+        "state": {
+          "on": "Readable",
+          "off": "Not readable"
+        }
+      }
+    },
+    "sensor": {
+      "last_error": {
+        "name": "Last Error"
+      },
+      "density": {
+        "name": "Print Density"
+      },
+      "printspeed": {
+        "name": "Print Speed"
+      },
+      "labeltype": {
+        "name": "Label Type"
+      },
+      "labels_remaining": {
+        "name": "Labels Remaining"
+      },
+      "labels_used": {
+        "name": "Labels Used"
+      },
+      "labels_total": {
+        "name": "Labels Total"
+      },
+      "consumable_usage": {
+        "name": "Consumable Usage"
+      },
+      "label_sku": {
+        "name": "Label SKU"
+      },
+      "consumable_type": {
+        "name": "Consumable Type"
+      },
+      "tag_uuid": {
+        "name": "Tag UUID"
+      },
+      "print_duration": {
+        "name": "Print Duration"
+      },
+      "print_progress": {
+        "name": "Print Progress"
+      }
+    },
+    "select": {
+      "auto_shutdown": {
+        "name": "Auto Shutdown",
+        "state": {
+          "15_min": "15 min",
+          "30_min": "30 min",
+          "45_60_min": "45–60 min",
+          "60_min_never": "60 min / never"
+        }
+      }
+    },
+    "switch": {
+      "connection_sound": {
+        "name": "Connection Sound",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        }
+      }
+    },
+    "image": {
+      "last_label_made": {
+        "name": "Last Label Made"
+      }
+    }
   }
 }

--- a/custom_components/niimbot/switch.py
+++ b/custom_components/niimbot/switch.py
@@ -45,7 +45,7 @@ class NiimbotConnectionSoundSwitch(
     """Switch for Bluetooth connection beep."""
 
     _attr_has_entity_name = True
-    _attr_name = "Connection Sound"
+    _attr_translation_key = "connection_sound"
     _attr_icon = "mdi:volume-high"
     _attr_entity_category = EntityCategory.CONFIG
 

--- a/custom_components/niimbot/translations/en.json
+++ b/custom_components/niimbot/translations/en.json
@@ -89,5 +89,89 @@
             "name": "Refresh Printer Info",
             "description": "Re-read cached printer settings (density, speed, label type, auto shutdown, battery bucket)."
         }
+    },
+    "entity": {
+        "binary_sensor": {
+            "paper": {
+                "name": "Paper",
+                "state": {
+                    "on": "Loaded",
+                    "off": "Empty"
+                }
+            },
+            "rfid": {
+                "name": "RFID",
+                "state": {
+                    "on": "Readable",
+                    "off": "Not readable"
+                }
+            }
+        },
+        "sensor": {
+            "last_error": {
+                "name": "Last Error"
+            },
+            "density": {
+                "name": "Print Density"
+            },
+            "printspeed": {
+                "name": "Print Speed"
+            },
+            "labeltype": {
+                "name": "Label Type"
+            },
+            "labels_remaining": {
+                "name": "Labels Remaining"
+            },
+            "labels_used": {
+                "name": "Labels Used"
+            },
+            "labels_total": {
+                "name": "Labels Total"
+            },
+            "consumable_usage": {
+                "name": "Consumable Usage"
+            },
+            "label_sku": {
+                "name": "Label SKU"
+            },
+            "consumable_type": {
+                "name": "Consumable Type"
+            },
+            "tag_uuid": {
+                "name": "Tag UUID"
+            },
+            "print_duration": {
+                "name": "Print Duration"
+            },
+            "print_progress": {
+                "name": "Print Progress"
+            }
+        },
+        "select": {
+            "auto_shutdown": {
+                "name": "Auto Shutdown",
+                "state": {
+                    "15_min": "15 min",
+                    "30_min": "30 min",
+                    "45_60_min": "45–60 min",
+                    "60_min_never": "60 min / never"
+                }
+            }
+        },
+        "switch": {
+            "connection_sound": {
+                "name": "Connection Sound",
+                "state": {
+                    "on": "On",
+                    "off": "Off"
+                }
+            }
+        },
+        "image": {
+            "last_label_made": {
+                "name": "Last Label Made"
+            }
+        }
     }
 }

--- a/custom_components/niimbot/translations/ko.json
+++ b/custom_components/niimbot/translations/ko.json
@@ -89,5 +89,89 @@
             "name": "프린터 정보 새로고침",
             "description": "캐시된 프린터 설정(농도, 속도, 라벨 타입, 자동 종료, 배터리 버킷)을 다시 읽습니다."
         }
+    },
+    "entity": {
+        "binary_sensor": {
+            "paper": {
+                "name": "용지",
+                "state": {
+                    "on": "장착됨",
+                    "off": "없음"
+                }
+            },
+            "rfid": {
+                "name": "RFID",
+                "state": {
+                    "on": "읽기 가능",
+                    "off": "읽기 불가"
+                }
+            }
+        },
+        "sensor": {
+            "last_error": {
+                "name": "최근 오류"
+            },
+            "density": {
+                "name": "인쇄 농도"
+            },
+            "printspeed": {
+                "name": "인쇄 속도"
+            },
+            "labeltype": {
+                "name": "라벨 타입"
+            },
+            "labels_remaining": {
+                "name": "남은 라벨"
+            },
+            "labels_used": {
+                "name": "사용한 라벨"
+            },
+            "labels_total": {
+                "name": "전체 라벨"
+            },
+            "consumable_usage": {
+                "name": "소모품 사용률"
+            },
+            "label_sku": {
+                "name": "라벨 SKU"
+            },
+            "consumable_type": {
+                "name": "소모품 타입"
+            },
+            "tag_uuid": {
+                "name": "태그 UUID"
+            },
+            "print_duration": {
+                "name": "인쇄 시간"
+            },
+            "print_progress": {
+                "name": "인쇄 진행률"
+            }
+        },
+        "select": {
+            "auto_shutdown": {
+                "name": "자동 종료",
+                "state": {
+                    "15_min": "15분",
+                    "30_min": "30분",
+                    "45_60_min": "45–60분",
+                    "60_min_never": "60분 / 안 함"
+                }
+            }
+        },
+        "switch": {
+            "connection_sound": {
+                "name": "연결음",
+                "state": {
+                    "on": "켜짐",
+                    "off": "꺼짐"
+                }
+            }
+        },
+        "image": {
+            "last_label_made": {
+                "name": "최근 라벨"
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Add `translation_key` translations (EN/KO) for sensors, select, switch, and image entities
- Paper / RFID binary sensors show Loaded·Empty and Readable·Not readable instead of On/Off
- Battery, Connection, and Lid keep Home Assistant device-class names/states (no custom translations)

## Test plan
- [ ] Reload integration with HA language Korean
- [ ] Confirm Paper shows 장착됨/없음 and RFID shows 읽기 가능/읽기 불가
- [ ] Confirm Battery / Connection / Lid still use core device-class strings
- [ ] Confirm Auto Shutdown options and other entity names are translated


Made with [Cursor](https://cursor.com)