### PR TITLE
Rename lid binary sensor to Cover

### DIFF
--- a/custom_components/niimbot/binary_sensor.py
+++ b/custom_components/niimbot/binary_sensor.py
@@ -36,10 +36,10 @@ class NiimbotBinarySensorEntityDescription(BinarySensorEntityDescription):
 BINARY_SENSORS: list[NiimbotBinarySensorEntityDescription] = [
     NiimbotBinarySensorEntityDescription(
         key="closingstate",
-        device_class=BinarySensorDeviceClass.DOOR,
-        icon="mdi:printer-alert",
+        translation_key="cover",
+        icon="mdi:tray",
         entity_category=EntityCategory.DIAGNOSTIC,
-        # closingstate != 0 means open; door device class: is_on=True means open
+        # closingstate != 0 means open (label cover). Custom name — not a door.
     ),
     NiimbotBinarySensorEntityDescription(
         key="paperstate",

--- a/custom_components/niimbot/strings.json
+++ b/custom_components/niimbot/strings.json
@@ -96,6 +96,13 @@
   },
     "entity": {
     "binary_sensor": {
+      "cover": {
+        "name": "Cover",
+        "state": {
+          "on": "Open",
+          "off": "Closed"
+        }
+      },
       "paper": {
         "name": "Paper",
         "state": {

--- a/custom_components/niimbot/translations/en.json
+++ b/custom_components/niimbot/translations/en.json
@@ -92,6 +92,13 @@
     },
     "entity": {
         "binary_sensor": {
+            "cover": {
+                "name": "Cover",
+                "state": {
+                    "on": "Open",
+                    "off": "Closed"
+                }
+            },
             "paper": {
                 "name": "Paper",
                 "state": {

--- a/custom_components/niimbot/translations/ko.json
+++ b/custom_components/niimbot/translations/ko.json
@@ -92,6 +92,13 @@
     },
     "entity": {
         "binary_sensor": {
+            "cover": {
+                "name": "커버",
+                "state": {
+                    "on": "열림",
+                    "off": "닫힘"
+                }
+            },
             "paper": {
                 "name": "용지",
                 "state": {


### PR DESCRIPTION
## Summary
- Replace the Door device class with a Cover entity name and Open/Closed states (EN/KO), matching the label bay cover rather than a door

## Test plan
- [ ] After update, the binary sensor shows as Cover / 커버 (not Door / 문)
- [ ] Open cover → Open / 열림; close → Closed / 닫힘


Made with [Cursor](https://cursor.com)