### PR TITLE
Select print sequence from capability, not model tuple (T4)

### DIFF
--- a/custom_components/niimbot/niimprint/model.py
+++ b/custom_components/niimbot/niimprint/model.py
@@ -389,7 +389,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     {
         "model": PrinterModel.S6,
         "generation": PrintGeneration.V4,
-        "id": [257, 258, 259, 260, 261, 262],
+        "id": [257, 258, 259, 261],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
         "printheadPixels": 576,
@@ -1056,6 +1056,7 @@ def _enrich_meta(meta: PrinterModelMeta) -> PrinterModelMeta:
 
 
 def get_printer_meta_by_id(printer_id: int) -> Union[PrinterModelMeta, None]:
+    """Look up printer metadata by model ID. First matching model entry in modelsLibrary wins."""
     for model in modelsLibrary:
         if printer_id in model["id"]:
             return _enrich_meta(model)

--- a/custom_components/niimbot/niimprint/model.py
+++ b/custom_components/niimbot/niimprint/model.py
@@ -1,6 +1,12 @@
 from enum import Enum
 from typing import List, NotRequired, TypedDict, Union
 
+class PrintGeneration(Enum):
+    OLD_D11 = "OLD_D11"
+    D110 = "D110"
+    V4 = "V4"
+    V5 = "V5"
+
 class PrintDirection(Enum):
     TOP = "top"
     LEFT = "left"
@@ -111,6 +117,7 @@ class PrinterModelMeta(TypedDict):
     printDirection: PrintDirection
     printheadPixels: int
     paperTypes: List[LabelType]
+    generation: PrintGeneration
     rfid: NotRequired[RfidClass]
     densityMin: NotRequired[int]
     densityMax: NotRequired[int]
@@ -120,6 +127,7 @@ class PrinterModelMeta(TypedDict):
 modelsLibrary: List[PrinterModelMeta] = [
     {
         "model": PrinterModel.B3S_P,
+        "generation": PrintGeneration.V4,
         "id": [272],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -128,6 +136,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.T2S,
+        "generation": PrintGeneration.V4,
         "id": [53250],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -136,6 +145,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.N1,
+        "generation": PrintGeneration.V4,
         "id": [3586],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -144,6 +154,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.TP2M_H,
+        "generation": PrintGeneration.V4,
         "id": [4609],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -152,6 +163,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B31,
+        "generation": PrintGeneration.V4,
         "id": [5632],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -160,6 +172,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B21_PRO,
+        "generation": PrintGeneration.V5,
         "id": [785],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -168,6 +181,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B2_PRO,
+        "generation": PrintGeneration.V5,
         "id": [6912],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -176,6 +190,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B2,
+        "generation": PrintGeneration.V4,
         "id": [6913],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -184,6 +199,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B18S,
+        "generation": PrintGeneration.V4,
         "id": [3585],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -192,6 +208,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.D11_H,
+        "generation": PrintGeneration.V5,
         "id": [528],
         "dpi": 300,
         "printDirection": PrintDirection.LEFT,
@@ -200,6 +217,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B21_H,
+        "generation": PrintGeneration.V4,
         "id": [784],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -208,6 +226,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.HI_D110,
+        "generation": PrintGeneration.V4,
         "id": [2305],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -216,6 +235,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.D110_M,
+        "generation": PrintGeneration.V5,
         "id": [2320],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -224,6 +244,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.M2_H,
+        "generation": PrintGeneration.V4,
         "id": [4608],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -232,6 +253,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.A20,
+        "generation": PrintGeneration.V4,
         "id": [2817],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -240,6 +262,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.MP3K_W,
+        "generation": PrintGeneration.V4,
         "id": [4867],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -248,6 +271,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.A203,
+        "generation": PrintGeneration.V4,
         "id": [2818],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -256,6 +280,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.MP3K,
+        "generation": PrintGeneration.V4,
         "id": [4866],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -264,6 +289,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.K3_W,
+        "generation": PrintGeneration.V4,
         "id": [4865],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -272,6 +298,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.K3,
+        "generation": PrintGeneration.V4,
         "id": [4864],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -280,6 +307,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.BETTY,
+        "generation": PrintGeneration.V4,
         "id": [2561],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -288,6 +316,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.T8S,
+        "generation": PrintGeneration.V4,
         "id": [2053],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -296,6 +325,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B21S,
+        "generation": PrintGeneration.D110,
         "id": [777],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -304,6 +334,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B21_L2B,
+        "generation": PrintGeneration.V4,
         "id": [769],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -312,6 +343,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.D11S,
+        "generation": PrintGeneration.OLD_D11,
         "id": [514],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -320,6 +352,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.A63,
+        "generation": PrintGeneration.V4,
         "id": [2054],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -328,6 +361,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.FUST,
+        "generation": PrintGeneration.V4,
         "id": [513],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -336,6 +370,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.P1,
+        "generation": PrintGeneration.V4,
         "id": [1024],
         "dpi": 300,
         "printDirection": PrintDirection.LEFT,
@@ -344,6 +379,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.P18,
+        "generation": PrintGeneration.V4,
         "id": [1026],
         "dpi": 300,
         "printDirection": PrintDirection.LEFT,
@@ -352,6 +388,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.S6,
+        "generation": PrintGeneration.V4,
         "id": [257, 258, 259, 260, 261, 262],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -360,6 +397,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B21S_C2B,
+        "generation": PrintGeneration.D110,
         "id": [776],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -368,6 +406,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.P1S,
+        "generation": PrintGeneration.V4,
         "id": [1025],
         "dpi": 300,
         "printDirection": PrintDirection.LEFT,
@@ -376,6 +415,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B1,
+        "generation": PrintGeneration.V4,
         "id": [4096],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -384,6 +424,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B1_PRO,
+        "generation": PrintGeneration.V4,
         "id": [4097],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -392,6 +433,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.A8,
+        "generation": PrintGeneration.V4,
         "id": [256],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -400,6 +442,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B21_C2B,
+        "generation": PrintGeneration.V4,
         "id": [771, 775],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -408,6 +451,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.Z401,
+        "generation": PrintGeneration.V4,
         "id": [2051],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -416,6 +460,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B16,
+        "generation": PrintGeneration.V4,
         "id": [1792],
         "dpi": 203,
         # Print direction 270 in vendor DB; modelled as LEFT for now.
@@ -425,6 +470,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B32R,
+        "generation": PrintGeneration.V4,
         "id": [2050],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -433,6 +479,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B32,
+        "generation": PrintGeneration.V4,
         "id": [2049],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -441,6 +488,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.S3,
+        "generation": PrintGeneration.V4,
         "id": [51460],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -449,6 +497,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.JC_M90,
+        "generation": PrintGeneration.V4,
         "id": [51461],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -457,6 +506,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.JCB3S,
+        "generation": PrintGeneration.V4,
         "id": [256],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -465,6 +515,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B203,
+        "generation": PrintGeneration.V4,
         "id": [2816],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -473,6 +524,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.S1,
+        "generation": PrintGeneration.V4,
         "id": [51458],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -481,6 +533,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.D110,
+        "generation": PrintGeneration.D110,
         "id": [2304, 2305],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -489,6 +542,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B21,
+        "generation": PrintGeneration.V4,
         "id": [768],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -497,6 +551,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.D101,
+        "generation": PrintGeneration.V4,
         "id": [2560],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -505,6 +560,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.HI_NB_D11,
+        "generation": PrintGeneration.V4,
         "id": [512],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -513,6 +569,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.A8_P,
+        "generation": PrintGeneration.V4,
         "id": [273],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -521,6 +578,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.S6_P,
+        "generation": PrintGeneration.V4,
         "id": [274],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -529,6 +587,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.T6,
+        "generation": PrintGeneration.V4,
         "id": [51715],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -537,6 +596,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B50W,
+        "generation": PrintGeneration.V4,
         "id": [51714],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -545,6 +605,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.T7,
+        "generation": PrintGeneration.V4,
         "id": [51717],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -553,6 +614,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.T8,
+        "generation": PrintGeneration.V4,
         "id": [51718],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -561,6 +623,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B3S,
+        "generation": PrintGeneration.V4,
         "id": [256, 260, 262],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -569,6 +632,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B3,
+        "generation": PrintGeneration.V4,
         "id": [52993],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -577,6 +641,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B18,
+        "generation": PrintGeneration.V4,
         "id": [3584],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -585,6 +650,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.D11,
+        "generation": PrintGeneration.OLD_D11,
         "id": [512],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -593,6 +659,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.D11_PRO,
+        "generation": PrintGeneration.V5,
         "id": [531],
         "dpi": 300,
         "printDirection": PrintDirection.LEFT,
@@ -601,6 +668,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B11,
+        "generation": PrintGeneration.V4,
         "id": [51457],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -609,6 +677,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B50,
+        "generation": PrintGeneration.V4,
         "id": [51713],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -617,6 +686,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.ET10,
+        "generation": PrintGeneration.V4,
         "id": [5376],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -625,6 +695,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.H1,
+        "generation": PrintGeneration.V4,
         "id": [3840],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -634,6 +705,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B1_SE,
+        "generation": PrintGeneration.V4,
         "id": [4098],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -643,6 +715,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.H1S,
+        "generation": PrintGeneration.V4,
         "id": [4352],
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
@@ -652,6 +725,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.EP2M_H,
+        "generation": PrintGeneration.V4,
         "id": [4610],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -661,6 +735,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.K3_ITD,
+        "generation": PrintGeneration.V4,
         "id": [4868],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -670,6 +745,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.C1,
+        "generation": PrintGeneration.V4,
         "id": [5120],
         "dpi": 300,
         "printDirection": PrintDirection.LEFT,
@@ -679,6 +755,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.EP1C,
+        "generation": PrintGeneration.V4,
         "id": [5121],
         "dpi": 300,
         "printDirection": PrintDirection.LEFT,
@@ -688,6 +765,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.K2,
+        "generation": PrintGeneration.V4,
         "id": [6144],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -697,6 +775,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.M3,
+        "generation": PrintGeneration.V4,
         "id": [6400],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -706,6 +785,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.EP3M,
+        "generation": PrintGeneration.V4,
         "id": [6402],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -715,6 +795,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B4,
+        "generation": PrintGeneration.V4,
         "id": [6656],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -724,6 +805,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.B4_PRO,
+        "generation": PrintGeneration.V4,
         "id": [6657],
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
@@ -733,6 +815,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.K4,
+        "generation": PrintGeneration.V4,
         "id": [7168],
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
@@ -742,6 +825,7 @@ modelsLibrary: List[PrinterModelMeta] = [
     },
     {
         "model": PrinterModel.A1_PRO,
+        "generation": PrintGeneration.V4,
         "id": [7424],
         "dpi": 300,
         # Print direction 270 in vendor DB; modelled as LEFT for now.

--- a/custom_components/niimbot/niimprint/printer.py
+++ b/custom_components/niimbot/niimprint/printer.py
@@ -11,7 +11,7 @@ from bleak import BleakClient, BleakError
 from typing import Any, Callable, TypeVar
 from asyncio import Event, wait_for, sleep
 from .packet import NiimbotPacket
-from .model import PrinterModel, get_printer_meta_by_model
+from .model import PrinterModel, PrintGeneration, get_printer_meta_by_model
 
 
 WrapFuncType = TypeVar("WrapFuncType", bound=Callable[..., Any])
@@ -302,14 +302,37 @@ class PrinterClient:
                 density_max=density_max,
                 copies=copies,
             )
-            if model in (PrinterModel.UNKNOWN, PrinterModel.D11, PrinterModel.D11S):
-                return await self.print_image_d11_v1(**kwargs)
-            elif model in (PrinterModel.B21S, PrinterModel.B21S_C2B, PrinterModel.D110):
+            generation = meta.get("generation") if meta else None
+
+            if generation is None:
+                proto_ver = None
+                try:
+                    status_data = await self.get_printer_status_data()
+                    if status_data:
+                        proto_ver = status_data.get("protocol_version")
+                except Exception as err:
+                    _LOGGER.debug("Failed to read PrinterStatusData for fallback: %s", err)
+
+                if proto_ver is not None and proto_ver >= 5:
+                    generation = PrintGeneration.V5
+                elif proto_ver is not None and proto_ver in (3, 4):
+                    generation = PrintGeneration.V4
+                else:
+                    generation = PrintGeneration.V4
+                    _LOGGER.warning(
+                        "Unknown printer model %r (protocol_version=%s); defaulting to PrintGeneration.V4 sequence",
+                        model,
+                        proto_ver,
+                    )
+
+            if generation == PrintGeneration.OLD_D11:
+                return await self.print_image_old_d11(**kwargs)
+            elif generation == PrintGeneration.D110:
                 return await self.print_image_d110(**kwargs)
-            elif model in (PrinterModel.D11_H, PrinterModel.D11_PRO, PrinterModel.B21_PRO, PrinterModel.D110_M, PrinterModel.B2_PRO):
-                return await self.print_image_d110m_v4(**kwargs)
+            elif generation == PrintGeneration.V5:
+                return await self.print_image_v5(**kwargs)
             else:
-                return await self.print_image_b1(**kwargs)
+                return await self.print_image_v4(**kwargs)
         finally:
             avg = (sum(self._timings) / len(self._timings)) if self._timings else 0.0
             _LOGGER.debug(
@@ -318,7 +341,7 @@ class PrinterClient:
                 avg,
             )
 
-    async def print_image_d11_v1(
+    async def print_image_old_d11(
         self,
         image: Image.Image,
         density,
@@ -331,7 +354,7 @@ class PrinterClient:
         copies: int = 1,
     ):
         """Print task for older D11 printers (OldD11PrintTask from niimblue)."""
-        _LOGGER.debug("print_image_d11_v1: %s", locals())
+        _LOGGER.debug("print_image_old_d11: %s", locals())
         await self.set_label_density(density, density_min, density_max)
         await self.set_label_type(label_type)
         await self.start_print()
@@ -349,7 +372,7 @@ class PrinterClient:
         await self.wait_print_complete(copies=copies)
         await self.end_print()
 
-    async def print_image_b1(
+    async def print_image_v4(
         self,
         image: Image.Image,
         density,
@@ -361,7 +384,7 @@ class PrinterClient:
         density_max: int = 5,
         copies: int = 1,
     ):
-        _LOGGER.debug("print_image_b1: %s", locals())
+        _LOGGER.debug("print_image_v4: %s", locals())
         await self.set_label_density(density, density_min, density_max)
         await self.set_label_type(label_type)
         await self.start_print_v4(total_pages=1)
@@ -406,7 +429,7 @@ class PrinterClient:
         await self.wait_print_complete(copies=copies)
         await self.end_print()
 
-    async def print_image_d110m_v4(
+    async def print_image_v5(
         self,
         image: Image.Image,
         density,
@@ -418,7 +441,7 @@ class PrinterClient:
         density_max: int = 5,
         copies: int = 1,
     ):
-        _LOGGER.debug("print_image_d110m_v4: %s", locals())
+        _LOGGER.debug("print_image_v5: %s", locals())
         if not await self.set_label_density(density, density_min, density_max):
             raise RuntimeError(f"Could not set label density to {density}")
         if not await self.set_label_type(label_type):

--- a/custom_components/niimbot/niimprint/printer.py
+++ b/custom_components/niimbot/niimprint/printer.py
@@ -305,25 +305,20 @@ class PrinterClient:
             generation = meta.get("generation") if meta else None
 
             if generation is None:
-                proto_ver = None
-                try:
-                    status_data = await self.get_printer_status_data()
-                    if status_data:
-                        proto_ver = status_data.get("protocol_version")
-                except Exception as err:
-                    _LOGGER.debug("Failed to read PrinterStatusData for fallback: %s", err)
+                status_data = await self.get_printer_status_data()
+                proto_ver = status_data.get("protocol_version") if status_data else None
 
                 if proto_ver is not None and proto_ver >= 5:
                     generation = PrintGeneration.V5
-                elif proto_ver is not None and proto_ver in (3, 4):
-                    generation = PrintGeneration.V4
                 else:
                     generation = PrintGeneration.V4
-                    _LOGGER.warning(
-                        "Unknown printer model %r (protocol_version=%s); defaulting to PrintGeneration.V4 sequence",
-                        model,
-                        proto_ver,
-                    )
+
+                _LOGGER.warning(
+                    "Unknown printer model %r (protocol_version=%s); defaulting to %s sequence",
+                    model,
+                    proto_ver,
+                    generation.value,
+                )
 
             if generation == PrintGeneration.OLD_D11:
                 return await self.print_image_old_d11(**kwargs)

--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -90,7 +90,7 @@ Entities are created dynamically only when the Advanced2 payload provides the va
 
 All 14 model IDs (3840, 4098, 4352, 4610, 4868, 5120, 5121, 6144, 6400, 6402, 6656, 6657, 7168, 7424) added to `PrinterModel`, `modelsLibrary`, and `_CAPABILITIES_BY_ID`. `printheadPixels` uses estimated values from same-series siblings and DPI pixel ratios, flagged with `printheadPixelsEstimated: True` with warning logging on print jobs. **[HW]** per model; A1 Pro print direction 270 is modelled as LEFT.
 
-### 4. Choose the print sequence from capability, not a model list (5.2)
+### 4. Choose the print sequence from capability, not a model list — **Done (T4)** (was 5.2)
 
 `print_image` dispatches on hardcoded model tuples, so every new model needs a code change in the
 right branch and an unlisted model falls through to `print_image_b1` — or, for `UNKNOWN`, to the

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -160,7 +160,7 @@ label in and back out without imaging it, with the page counter not advancing.
 
 ### Old D11 generation
 
-Models: D11, D11S, and anything unrecognised.
+Models: D11, D11S.
 
 ```
 SetDensity → SetLabelType → PrintStart(1b) → PrintClear
@@ -183,7 +183,7 @@ SetDensity → SetLabelType → PrintStart(1b)
 
 ### V4 generation
 
-Models: B1, B1 Pro, B21, B3S — everything not matched by another branch.
+Models: B1, B1 Pro, B21, B3S, etc. — default fallback for unrecognised models (unless protocol version >= 5).
 
 ```
 SetDensity → SetLabelType → PrintStart(7b)

--- a/docs/work-plan.md
+++ b/docs/work-plan.md
@@ -242,7 +242,7 @@ measured.
 
 ---
 
-## T4 — Select the print sequence from capability, not a model tuple [COMPLETED]
+## T4 — Select the print sequence from capability, not a model tuple [Done]
 
 **Goal.** An unrecognised printer should pick a sane sequence instead of the oldest one.
 

--- a/docs/work-plan.md
+++ b/docs/work-plan.md
@@ -242,7 +242,7 @@ measured.
 
 ---
 
-## T4 — Select the print sequence from capability, not a model tuple
+## T4 — Select the print sequence from capability, not a model tuple [COMPLETED]
 
 **Goal.** An unrecognised printer should pick a sane sequence instead of the oldest one.
 

--- a/tests/test_print_sequence.py
+++ b/tests/test_print_sequence.py
@@ -57,7 +57,7 @@ def _build_standard_responses():
         NiimbotPacket(4, b"\x01"),    # START_PAGE_PRINT (0x03 + 1 = 4)
         NiimbotPacket(20, b"\x01"),   # SET_DIMENSION (0x13 + 1 = 20)
         NiimbotPacket(22, b"\x01"),   # SET_QUANTITY (0x15 + 1 = 22)
-        NiimbotPacket(134, b"\x01"),  # PRINT_BITMAP_ROW_INDEXED (0x83 + 1 = 134)
+        NiimbotPacket(132, b"\x01"),  # PRINT_BITMAP_ROW_INDEXED (0x83 + 1 = 132)
         NiimbotPacket(228, b"\x01"),  # END_PAGE_PRINT (0xE3 + 1 = 228)
         NiimbotPacket(PAGE_INDEX_CMD, struct.pack(">H", 1)), # Page index 1 complete
         NiimbotPacket(244, b"\x01"),  # END_PRINT (0xF3 + 1 = 244)
@@ -88,6 +88,45 @@ def test_print_sequence_old_d11():
     run(_test())
 
 
+def test_print_sequence_d110():
+    async def _test():
+        responses = [
+            NiimbotPacket(49, b"\x01"),   # SET_LABEL_DENSITY
+            NiimbotPacket(51, b"\x01"),   # SET_LABEL_TYPE
+            NiimbotPacket(2, b"\x01"),    # START_PRINT (1 byte b"\x01")
+            NiimbotPacket(4, b"\x01"),    # START_PAGE_PRINT
+            NiimbotPacket(20, b"\x01"),   # SET_DIMENSION
+            NiimbotPacket(22, b"\x01"),   # SET_QUANTITY
+            NiimbotPacket(132, b"\x01"),  # PRINT_BITMAP_ROW_INDEXED
+            NiimbotPacket(228, b"\x01"),  # END_PAGE_PRINT
+            NiimbotPacket(PAGE_INDEX_CMD, struct.pack(">H", 1)),
+            NiimbotPacket(244, b"\x01"),  # END_PRINT
+        ]
+        transport = FakeTransport(responses)
+        client = PrinterClient(transport=transport)
+        img = Image.new("1", (96, 10))
+
+        await client.print_image(
+            PrinterModel.D110,
+            img,
+            density=3,
+            wait_between_print_lines=0,
+            print_line_batch_size=1,
+        )
+
+        sent_types = [p.type for p in transport.written_packets]
+        assert RequestCodeEnum.START_PRINT in sent_types
+        # D110 sends 1-byte START_PRINT, SET_QUANTITY, but NOT ALLOW_PRINT_CLEAR
+        assert RequestCodeEnum.ALLOW_PRINT_CLEAR not in sent_types
+        assert RequestCodeEnum.SET_QUANTITY in sent_types
+        start_print_pkt = next(
+            p for p in transport.written_packets if p.type == RequestCodeEnum.START_PRINT
+        )
+        assert len(start_print_pkt.data) == 1
+
+    run(_test())
+
+
 def test_print_sequence_v4():
     async def _test():
         responses = [
@@ -96,7 +135,7 @@ def test_print_sequence_v4():
             NiimbotPacket(2, b"\x01"),    # START_PRINT (v4)
             NiimbotPacket(4, b"\x01"),    # START_PAGE_PRINT
             NiimbotPacket(20, b"\x01"),   # SET_DIMENSION
-            NiimbotPacket(134, b"\x01"),  # PRINT_BITMAP_ROW_INDEXED
+            NiimbotPacket(132, b"\x01"),  # PRINT_BITMAP_ROW_INDEXED
             NiimbotPacket(228, b"\x01"),  # END_PAGE_PRINT
             NiimbotPacket(PAGE_INDEX_CMD, struct.pack(">H", 1)),
             NiimbotPacket(244, b"\x01"),  # END_PRINT

--- a/tests/test_print_sequence.py
+++ b/tests/test_print_sequence.py
@@ -1,0 +1,232 @@
+"""Tests for print sequence dispatch and generation mappings."""
+
+import asyncio
+import struct
+
+from PIL import Image
+
+from custom_components.niimbot.niimprint.model import (
+    PrinterModel,
+    PrintGeneration,
+    modelsLibrary,
+)
+from custom_components.niimbot.niimprint.packet import NiimbotPacket
+from custom_components.niimbot.niimprint.printer import (
+    PAGE_INDEX_CMD,
+    PRINTER_STATUS_DATA_RESP,
+    PrinterClient,
+    RequestCodeEnum,
+)
+from tests.fake_transport import FakeTransport
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_models_library_generation_assignments():
+    old_d11_models = {PrinterModel.D11, PrinterModel.D11S}
+    d110_models = {PrinterModel.D110, PrinterModel.B21S, PrinterModel.B21S_C2B}
+    v5_models = {
+        PrinterModel.D11_H,
+        PrinterModel.D11_PRO,
+        PrinterModel.B21_PRO,
+        PrinterModel.D110_M,
+        PrinterModel.B2_PRO,
+    }
+
+    for meta in modelsLibrary:
+        model = meta["model"]
+        gen = meta["generation"]
+        if model in old_d11_models:
+            assert gen == PrintGeneration.OLD_D11, f"{model} expected OLD_D11, got {gen}"
+        elif model in d110_models:
+            assert gen == PrintGeneration.D110, f"{model} expected D110, got {gen}"
+        elif model in v5_models:
+            assert gen == PrintGeneration.V5, f"{model} expected V5, got {gen}"
+        else:
+            assert gen == PrintGeneration.V4, f"{model} expected V4, got {gen}"
+
+
+def _build_standard_responses():
+    return [
+        NiimbotPacket(49, b"\x01"),   # SET_LABEL_DENSITY (0x21 + 16 = 49)
+        NiimbotPacket(51, b"\x01"),   # SET_LABEL_TYPE (0x23 + 16 = 51)
+        NiimbotPacket(2, b"\x01"),    # START_PRINT (0x01 + 1 = 2)
+        NiimbotPacket(48, b"\x01"),   # ALLOW_PRINT_CLEAR (0x20 + 16 = 48)
+        NiimbotPacket(4, b"\x01"),    # START_PAGE_PRINT (0x03 + 1 = 4)
+        NiimbotPacket(20, b"\x01"),   # SET_DIMENSION (0x13 + 1 = 20)
+        NiimbotPacket(22, b"\x01"),   # SET_QUANTITY (0x15 + 1 = 22)
+        NiimbotPacket(134, b"\x01"),  # PRINT_BITMAP_ROW_INDEXED (0x83 + 1 = 134)
+        NiimbotPacket(228, b"\x01"),  # END_PAGE_PRINT (0xE3 + 1 = 228)
+        NiimbotPacket(PAGE_INDEX_CMD, struct.pack(">H", 1)), # Page index 1 complete
+        NiimbotPacket(244, b"\x01"),  # END_PRINT (0xF3 + 1 = 244)
+    ]
+
+
+def test_print_sequence_old_d11():
+    async def _test():
+        responses = _build_standard_responses()
+        transport = FakeTransport(responses)
+        client = PrinterClient(transport=transport)
+        img = Image.new("1", (96, 10))
+
+        await client.print_image(
+            PrinterModel.D11,
+            img,
+            density=3,
+            wait_between_print_lines=0,
+            print_line_batch_size=1,
+        )
+
+        sent_types = [p.type for p in transport.written_packets]
+        # OLD_D11 sequence includes ALLOW_PRINT_CLEAR (0x20)
+        assert RequestCodeEnum.ALLOW_PRINT_CLEAR in sent_types
+        # OLD_D11 sequence includes SET_QUANTITY (0x15)
+        assert RequestCodeEnum.SET_QUANTITY in sent_types
+
+    run(_test())
+
+
+def test_print_sequence_v4():
+    async def _test():
+        responses = [
+            NiimbotPacket(49, b"\x01"),   # SET_LABEL_DENSITY
+            NiimbotPacket(51, b"\x01"),   # SET_LABEL_TYPE
+            NiimbotPacket(2, b"\x01"),    # START_PRINT (v4)
+            NiimbotPacket(4, b"\x01"),    # START_PAGE_PRINT
+            NiimbotPacket(20, b"\x01"),   # SET_DIMENSION
+            NiimbotPacket(134, b"\x01"),  # PRINT_BITMAP_ROW_INDEXED
+            NiimbotPacket(228, b"\x01"),  # END_PAGE_PRINT
+            NiimbotPacket(PAGE_INDEX_CMD, struct.pack(">H", 1)),
+            NiimbotPacket(244, b"\x01"),  # END_PRINT
+        ]
+        transport = FakeTransport(responses)
+        client = PrinterClient(transport=transport)
+        img = Image.new("1", (384, 10))
+
+        await client.print_image(
+            PrinterModel.B1,
+            img,
+            density=3,
+            wait_between_print_lines=0,
+            print_line_batch_size=1,
+        )
+
+        sent_types = [p.type for p in transport.written_packets]
+        # V4 sends START_PRINT (0x01)
+        assert RequestCodeEnum.START_PRINT in sent_types
+        # V4 does NOT send ALLOW_PRINT_CLEAR (0x20)
+        assert RequestCodeEnum.ALLOW_PRINT_CLEAR not in sent_types
+
+    run(_test())
+
+
+def test_print_sequence_v5():
+    async def _test():
+        responses = [
+            NiimbotPacket(49, b"\x01"),   # SET_LABEL_DENSITY
+            NiimbotPacket(51, b"\x01"),   # SET_LABEL_TYPE
+            NiimbotPacket(2, b"\x01"),    # START_PRINT_9B
+            NiimbotPacket(20, b"\x01"),   # SET_PAGE_SIZE_9B
+            NiimbotPacket(134, b"\x01"),  # PRINT_BITMAP_ROW_INDEXED
+            NiimbotPacket(228, b"\x01"),  # END_PAGE_PRINT
+            NiimbotPacket(PAGE_INDEX_CMD, struct.pack(">H", 1)),
+            NiimbotPacket(244, b"\x01"),  # END_PRINT
+        ]
+        transport = FakeTransport(responses)
+        client = PrinterClient(transport=transport)
+        img = Image.new("1", (178, 10))
+
+        await client.print_image(
+            PrinterModel.D11_H,
+            img,
+            density=3,
+            wait_between_print_lines=0,
+            print_line_batch_size=1,
+        )
+
+        # V5 start_print sends struct.pack(">HBBBBBBB", ...) -> 9 bytes payload
+        start_print_pkt = next(
+            p for p in transport.written_packets if p.type == RequestCodeEnum.START_PRINT
+        )
+        assert len(start_print_pkt.data) == 9
+
+    run(_test())
+
+
+def test_unknown_model_fallback_v5_via_protocol_version():
+    async def _test():
+        # Respond to PrinterStatusData (0xA5) with protocol version >= 302 -> 5
+        status_payload = bytearray(13)
+        status_payload[10] = 0  # support_color
+        status_payload[11] = 3  # raw_version high byte (3*100)
+        status_payload[12] = 2  # raw_version low byte (+2 = 302)
+
+        responses = [
+            NiimbotPacket(PRINTER_STATUS_DATA_RESP, bytes(status_payload)),
+            NiimbotPacket(49, b"\x01"),   # SET_LABEL_DENSITY
+            NiimbotPacket(51, b"\x01"),   # SET_LABEL_TYPE
+            NiimbotPacket(2, b"\x01"),    # START_PRINT_9B
+            NiimbotPacket(20, b"\x01"),   # SET_PAGE_SIZE_9B
+            NiimbotPacket(134, b"\x01"),  # PRINT_BITMAP_ROW_INDEXED
+            NiimbotPacket(228, b"\x01"),  # END_PAGE_PRINT
+            NiimbotPacket(PAGE_INDEX_CMD, struct.pack(">H", 1)),
+            NiimbotPacket(244, b"\x01"),  # END_PRINT
+        ]
+        transport = FakeTransport(responses)
+        client = PrinterClient(transport=transport)
+        img = Image.new("1", (200, 10))
+
+        await client.print_image(
+            PrinterModel.UNKNOWN,
+            img,
+            density=3,
+            wait_between_print_lines=0,
+            print_line_batch_size=1,
+        )
+
+        start_print_pkt = next(
+            p for p in transport.written_packets if p.type == RequestCodeEnum.START_PRINT
+        )
+        assert len(start_print_pkt.data) == 9
+
+    run(_test())
+
+
+def test_unknown_model_fallback_default_v4():
+    async def _test():
+        # PrinterStatusData fails (NAK packet 0) -> falls back to V4 sequence
+        responses = [
+            NiimbotPacket(0, b"\x00"),    # PrinterStatusData NAK
+            NiimbotPacket(49, b"\x01"),   # SET_LABEL_DENSITY
+            NiimbotPacket(51, b"\x01"),   # SET_LABEL_TYPE
+            NiimbotPacket(2, b"\x01"),    # START_PRINT (v4)
+            NiimbotPacket(4, b"\x01"),    # START_PAGE_PRINT
+            NiimbotPacket(20, b"\x01"),   # SET_DIMENSION
+            NiimbotPacket(134, b"\x01"),  # PRINT_BITMAP_ROW_INDEXED
+            NiimbotPacket(228, b"\x01"),  # END_PAGE_PRINT
+            NiimbotPacket(PAGE_INDEX_CMD, struct.pack(">H", 1)),
+            NiimbotPacket(244, b"\x01"),  # END_PRINT
+        ]
+        transport = FakeTransport(responses)
+        client = PrinterClient(transport=transport)
+        img = Image.new("1", (200, 10))
+
+        await client.print_image(
+            PrinterModel.UNKNOWN,
+            img,
+            density=3,
+            wait_between_print_lines=0,
+            print_line_batch_size=1,
+        )
+
+        sent_types = [p.type for p in transport.written_packets]
+        assert RequestCodeEnum.START_PRINT in sent_types
+        # V4 start_print sends struct.pack(">HBBBBB", ...) -> 7 bytes data
+        start_print_pkt = next(
+            p for p in transport.written_packets if p.type == RequestCodeEnum.START_PRINT
+        )
+        assert len(start_print_pkt.data) == 7
+
+    run(_test())


### PR DESCRIPTION
- Add PrintGeneration Enum (OLD_D11, D110, V4, V5) and generation field to PrinterModelMeta
- Populate generation field on all models in modelsLibrary
- Rename internal print methods to match documentation (print_image_old_d11, print_image_v4, print_image_v5)
- Update print_image() dispatch to use meta['generation'] or fallback to protocol_version from PrinterStatusData
- Change PrinterModel.UNKNOWN fallback default sequence from OLD_D11 to V4 (logs warning when falling back)
- Add unit tests in tests/test_print_sequence.py for mappings, packet sequences, and UNKNOWN fallbacks