### PR TITLE
Skip RFID reads on firmware versions known not to support RFID (T5)

### DIFF
--- a/custom_components/niimbot/niimprint/model.py
+++ b/custom_components/niimbot/niimprint/model.py
@@ -1070,6 +1070,8 @@ def get_printer_meta_by_model(model: PrinterModel) -> PrinterModelMeta | None:
     return None
 
 
+# Note: D41 / D61 / Dxx also have rfidNotSupportVersions in the vendor database,
+# but lack protocol model IDs so they cannot be keyed by ID in this table.
 _RFID_UNSUPPORTED_FIRMWARE: dict[int, frozenset[str]] = {
     512: frozenset({
         "1.01", "1.04", "1.05", "1.06", "1.07", "1.08", "1.09",
@@ -1101,10 +1103,13 @@ def rfid_supported_on_firmware(
     if not unsupported:
         return True
 
-    if isinstance(sw_version, (int, float)):
-        ver_str = f"{int(sw_version)}.{round((sw_version - int(sw_version)) * 100):02d}"
+    ver_str = str(sw_version).strip()
+    try:
+        v = float(ver_str)
+    except ValueError:
+        pass
     else:
-        ver_str = str(sw_version).strip()
+        ver_str = f"{int(v)}.{round((v - int(v)) * 100):02d}"
 
     return ver_str not in unsupported
 

--- a/custom_components/niimbot/niimprint/model.py
+++ b/custom_components/niimbot/niimprint/model.py
@@ -1,5 +1,6 @@
 from enum import Enum
-from typing import List, NotRequired, TypedDict, Union
+from typing import NotRequired, TypedDict
+
 
 class PrintGeneration(Enum):
     OLD_D11 = "OLD_D11"
@@ -112,11 +113,11 @@ class PrinterModel(Enum):
 
 class PrinterModelMeta(TypedDict):
     model: PrinterModel
-    id: List[int]
+    id: list[int]
     dpi: int
     printDirection: PrintDirection
     printheadPixels: int
-    paperTypes: List[LabelType]
+    paperTypes: list[LabelType]
     generation: PrintGeneration
     rfid: NotRequired[RfidClass]
     densityMin: NotRequired[int]
@@ -124,7 +125,7 @@ class PrinterModelMeta(TypedDict):
     densityDefault: NotRequired[int]
     printheadPixelsEstimated: NotRequired[bool]
 
-modelsLibrary: List[PrinterModelMeta] = [
+modelsLibrary: list[PrinterModelMeta] = [
     {
         "model": PrinterModel.B3S_P,
         "generation": PrintGeneration.V4,
@@ -1055,15 +1056,55 @@ def _enrich_meta(meta: PrinterModelMeta) -> PrinterModelMeta:
     return out
 
 
-def get_printer_meta_by_id(printer_id: int) -> Union[PrinterModelMeta, None]:
+def get_printer_meta_by_id(printer_id: int) -> PrinterModelMeta | None:
     """Look up printer metadata by model ID. First matching model entry in modelsLibrary wins."""
     for model in modelsLibrary:
         if printer_id in model["id"]:
             return _enrich_meta(model)
     return None
 
-def get_printer_meta_by_model(model: PrinterModel) -> Union[PrinterModelMeta, None]:
+def get_printer_meta_by_model(model: PrinterModel) -> PrinterModelMeta | None:
     for m in modelsLibrary:
         if m["model"] == model:
             return _enrich_meta(m)
     return None
+
+
+_RFID_UNSUPPORTED_FIRMWARE: dict[int, frozenset[str]] = {
+    512: frozenset({
+        "1.01", "1.04", "1.05", "1.06", "1.07", "1.08", "1.09",
+        "2.02", "2.03", "2.08", "2.09", "2.14", "2.15", "2.16",
+    }),
+    777: frozenset({
+        "1.01", "1.02", "1.03", "1.04", "2.01", "2.02", "2.03", "2.04",
+        "2.05", "2.06", "2.07", "2.08", "2.09", "3.01", "5.01", "5.02",
+        "6.00", "10.01", "20.01", "21.01", "30.01", "31.01", "32.01",
+        "33.01", "35.01",
+    }),
+}
+_RFID_UNSUPPORTED_FIRMWARE[771] = _RFID_UNSUPPORTED_FIRMWARE[777]
+_RFID_UNSUPPORTED_FIRMWARE[775] = _RFID_UNSUPPORTED_FIRMWARE[777]
+
+
+def rfid_supported_on_firmware(
+    model_id: int | str | None, sw_version: str | float | None
+) -> bool:
+    """Return False if model_id has known firmware versions where RFID reading fails."""
+    if model_id is None or sw_version is None:
+        return True
+    try:
+        mid = int(model_id)
+    except (TypeError, ValueError):
+        return True
+
+    unsupported = _RFID_UNSUPPORTED_FIRMWARE.get(mid)
+    if not unsupported:
+        return True
+
+    if isinstance(sw_version, (int, float)):
+        ver_str = f"{int(sw_version)}.{round((sw_version - int(sw_version)) * 100):02d}"
+    else:
+        ver_str = str(sw_version).strip()
+
+    return ver_str not in unsupported
+

--- a/custom_components/niimbot/niimprint/parser.py
+++ b/custom_components/niimbot/niimprint/parser.py
@@ -572,14 +572,11 @@ class NiimbotDevice:
             _LOGGER.debug("Obtained BLEData: %s", self.ble_data)
             return self.ble_data
 
-    async def _maybe_read_rfid(
-        self, printer: PrinterClient, heartbeat: dict, *, force: bool = False
-    ) -> None:
-        """Read label RFID when the model supports it."""
-        if not self.supports_label_rfid():
-            return
-
-        if not rfid_supported_on_firmware(self.ble_data.devicetype, self.ble_data.sw_version):
+    def _check_rfid_firmware_support(self) -> bool:
+        """Check if RFID reading is supported on this firmware version, logging once per connection."""
+        if not rfid_supported_on_firmware(
+            self.ble_data.devicetype, self.ble_data.sw_version
+        ):
             if not self._warned_rfid_firmware:
                 self._warned_rfid_firmware = True
                 _LOGGER.info(
@@ -588,6 +585,17 @@ class NiimbotDevice:
                     self.ble_data.devicetype,
                     self.ble_data.sw_version,
                 )
+            return False
+        return True
+
+    async def _maybe_read_rfid(
+        self, printer: PrinterClient, heartbeat: dict, *, force: bool = False
+    ) -> None:
+        """Read label RFID when the model supports it."""
+        if not self.supports_label_rfid():
+            return
+
+        if not self._check_rfid_firmware_support():
             return
 
         # Seed keys so entity platforms can discover them even before a tag read.
@@ -623,15 +631,10 @@ class NiimbotDevice:
         if not self.supports_ribbon_rfid():
             return
 
-        if not rfid_supported_on_firmware(self.ble_data.devicetype, self.ble_data.sw_version):
-            if not self._warned_rfid_firmware:
-                self._warned_rfid_firmware = True
-                _LOGGER.info(
-                    "Skipping RFID read for %s (model_id=%s, sw_version=%s): RFID unsupported on this firmware version",
-                    self.ble_data.model,
-                    self.ble_data.devicetype,
-                    self.ble_data.sw_version,
-                )
+        # Note: All currently gated model IDs (512, 771, 775, 777) are LABEL-class models,
+        # so supports_ribbon_rfid() returns False above for them. This gate check is kept
+        # for consistency if ribbon-class models with firmware gates are added in the future.
+        if not self._check_rfid_firmware_support():
             return
 
         for key in RIBBON_RFID_SENSOR_KEYS:

--- a/custom_components/niimbot/niimprint/parser.py
+++ b/custom_components/niimbot/niimprint/parser.py
@@ -1,25 +1,27 @@
 """Parser for Niimbot BLE devices"""
 
+import asyncio
 import dataclasses
 import logging
-import asyncio
 import time
 
-# from logging import Logger
-from PIL import Image, ImageOps
 from bleak import BleakClient
 from bleak.backends.device import BLEDevice
 from bleak_retry_connector import establish_connection
 
-from .printer import PrinterClient, InfoEnum, SoundEnum, PrinterTimeout, PrinterError
+# from logging import Logger
+from PIL import Image
+
 from .model import (
     PrinterModel,
     consumable_type_name,
     get_printer_meta_by_id,
     material_name,
+    rfid_supported_on_firmware,
     supports_label_rfid,
     supports_ribbon_rfid,
 )
+from .printer import InfoEnum, PrinterClient, PrinterError, PrinterTimeout, SoundEnum
 
 
 def _battery_percentage(
@@ -80,7 +82,7 @@ class BLEData:
     autoshutdowntime: int | None = None
     devicetype: str = ""
     sensors: dict[str, str | float | None] = dataclasses.field(
-        default_factory=lambda: {}
+        default_factory=dict
     )
 
 
@@ -142,6 +144,7 @@ class NiimbotDevice:
         self._print_progress_started = False
         self.heartbeat_variant: str | None = None
         self._warned_estimated_models: set[str] = set()
+        self._warned_rfid_firmware: bool = False
         super().__init__()
 
     def get_model_meta(self):
@@ -576,6 +579,17 @@ class NiimbotDevice:
         if not self.supports_label_rfid():
             return
 
+        if not rfid_supported_on_firmware(self.ble_data.devicetype, self.ble_data.sw_version):
+            if not self._warned_rfid_firmware:
+                self._warned_rfid_firmware = True
+                _LOGGER.info(
+                    "Skipping RFID read for %s (model_id=%s, sw_version=%s): RFID unsupported on this firmware version",
+                    self.ble_data.model,
+                    self.ble_data.devicetype,
+                    self.ble_data.sw_version,
+                )
+            return
+
         # Seed keys so entity platforms can discover them even before a tag read.
         for key in RFID_SENSOR_KEYS:
             self.ble_data.sensors.setdefault(key, None)
@@ -607,6 +621,17 @@ class NiimbotDevice:
     async def _maybe_read_ribbon_rfid(self, printer: PrinterClient) -> None:
         """Read ribbon RFID when the model supports it."""
         if not self.supports_ribbon_rfid():
+            return
+
+        if not rfid_supported_on_firmware(self.ble_data.devicetype, self.ble_data.sw_version):
+            if not self._warned_rfid_firmware:
+                self._warned_rfid_firmware = True
+                _LOGGER.info(
+                    "Skipping RFID read for %s (model_id=%s, sw_version=%s): RFID unsupported on this firmware version",
+                    self.ble_data.model,
+                    self.ble_data.devicetype,
+                    self.ble_data.sw_version,
+                )
             return
 
         for key in RIBBON_RFID_SENSOR_KEYS:

--- a/docs/improvement-plan.md
+++ b/docs/improvement-plan.md
@@ -108,7 +108,7 @@ renamed in the same change:
 | `print_image_b1` | V4 (`start_print_v4` + 6-byte `SetPageSize`) |
 | `print_image_d110m_v4` | V5 / 9-byte (`start_print_9b` + 9-byte `SetPageSize`) |
 
-### 5. Gate RFID reads on firmware version
+### 5. Gate RFID reads on firmware version — **Done (T5)**
 
 The vendor table lists, per model, the firmware versions on which RFID reading does not work
 ([app-gap-analysis.md §A4](app-gap-analysis.md#a4-firmware-version-gated-capabilities-are-ignored)).

--- a/docs/work-plan.md
+++ b/docs/work-plan.md
@@ -291,7 +291,7 @@ change. Verify by asserting against captured packets, not by inspection.
 
 ---
 
-## T5 — Skip RFID reads on firmware that cannot do RFID
+## T5 — Skip RFID reads on firmware that cannot do RFID [Done]
 
 **Goal.** Remove a guaranteed per-poll timeout on affected units.
 

--- a/tests/test_rfid_firmware_gate.py
+++ b/tests/test_rfid_firmware_gate.py
@@ -18,11 +18,14 @@ def test_rfid_supported_on_firmware_helper():
     assert not rfid_supported_on_firmware(512, "2.08")
     assert not rfid_supported_on_firmware("512", 2.08)
     assert not rfid_supported_on_firmware(512, "1.04")
+    assert rfid_supported_on_firmware(512, "2.1")
     assert rfid_supported_on_firmware(512, "2.10")
     assert rfid_supported_on_firmware(512, "3.00")
 
     # Model 777 (B21S)
     assert not rfid_supported_on_firmware(777, "2.08")
+    assert not rfid_supported_on_firmware(777, "6.0")
+    assert not rfid_supported_on_firmware(777, "6.00")
     assert not rfid_supported_on_firmware(777, "35.01")
     assert rfid_supported_on_firmware(777, "36.00")
 

--- a/tests/test_rfid_firmware_gate.py
+++ b/tests/test_rfid_firmware_gate.py
@@ -1,0 +1,92 @@
+"""Tests for firmware version gating of RFID reads."""
+
+import asyncio
+
+from custom_components.niimbot.niimprint.model import rfid_supported_on_firmware
+from custom_components.niimbot.niimprint.packet import NiimbotPacket
+from custom_components.niimbot.niimprint.parser import NiimbotDevice
+from custom_components.niimbot.niimprint.printer import PrinterClient, RequestCodeEnum
+from tests.fake_transport import FakeTransport
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_rfid_supported_on_firmware_helper():
+    # Model 512 (D11 / Hi-NB-D11)
+    assert not rfid_supported_on_firmware(512, "2.08")
+    assert not rfid_supported_on_firmware("512", 2.08)
+    assert not rfid_supported_on_firmware(512, "1.04")
+    assert rfid_supported_on_firmware(512, "2.10")
+    assert rfid_supported_on_firmware(512, "3.00")
+
+    # Model 777 (B21S)
+    assert not rfid_supported_on_firmware(777, "2.08")
+    assert not rfid_supported_on_firmware(777, "35.01")
+    assert rfid_supported_on_firmware(777, "36.00")
+
+    # Models 771 & 775 (B21-C2B)
+    assert not rfid_supported_on_firmware(771, "1.01")
+    assert not rfid_supported_on_firmware(775, "1.01")
+
+    # Model 4096 (B1 - no firmware gate)
+    assert rfid_supported_on_firmware(4096, "2.08")
+
+    # Fallback cases (None inputs)
+    assert rfid_supported_on_firmware(None, "2.08")
+    assert rfid_supported_on_firmware(512, None)
+    assert rfid_supported_on_firmware(None, None)
+
+
+def _rfid_payload():
+    uuid = bytes.fromhex("1122334455667788")
+    barcode = b"LAB001"
+    serial = b"S1"
+    data = bytearray(uuid)
+    data.append(len(barcode))
+    data.extend(barcode)
+    data.append(len(serial))
+    data.extend(serial)
+    data.extend((100).to_bytes(2, "big"))  # total_len
+    data.extend((10).to_bytes(2, "big"))   # used_len
+    data.append(1)                        # type
+    return bytes(data)
+
+
+def test_device_skips_rfid_on_unsupported_firmware():
+    async def _test():
+        transport = FakeTransport([])
+        printer = PrinterClient(transport=transport)
+        device = NiimbotDevice("11:22:33:44:55:66")
+        device.ble_data.devicetype = 512
+        device.ble_data.sw_version = "2.08"
+        device.ble_data.model = "D11"
+
+        heartbeat = {"rfidreadstate": 1}
+        await device._maybe_read_rfid(printer, heartbeat)
+
+        written_types = [p.type for p in transport.written_packets]
+        assert RequestCodeEnum.GET_RFID not in written_types
+
+    run(_test())
+
+
+def test_device_reads_rfid_on_supported_firmware():
+    async def _test():
+        rfid_bytes = _rfid_payload()
+        transport = FakeTransport([NiimbotPacket(27, rfid_bytes)])
+        printer = PrinterClient(transport=transport)
+        device = NiimbotDevice("11:22:33:44:55:66")
+        device.ble_data.devicetype = 512
+        device.ble_data.sw_version = "2.10"
+        device.ble_data.model = "D11"
+
+        heartbeat = {"rfidreadstate": 1}
+        await device._maybe_read_rfid(printer, heartbeat)
+
+        written_types = [p.type for p in transport.written_packets]
+        assert RequestCodeEnum.GET_RFID in written_types
+        assert device.ble_data.sensors["label_sku"] == "LAB001"
+
+    run(_test())


### PR DESCRIPTION
- Add _RFID_UNSUPPORTED_FIRMWARE dictionary and rfid_supported_on_firmware() helper in model.py
- Gate _maybe_read_rfid() and _maybe_read_ribbon_rfid() in parser.py with one-time INFO log per connection
- Add test_rfid_firmware_gate.py unit tests verifying helper and parser packet omission
- Update work-plan.md and improvement-plan.md status tags