### PR TITLE
Fix T7 paperTypes regression and stale protocol docs

### DIFF
--- a/custom_components/niimbot/niimprint/model.py
+++ b/custom_components/niimbot/niimprint/model.py
@@ -152,7 +152,13 @@ modelsLibrary: list[PrinterModelMeta] = [
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
         "printheadPixels": 120,
-        "paperTypes": [LabelType.WITH_GAPS, LabelType.HEAT_SHRINK_TUBE, LabelType.TRANSPARENT, LabelType.BLACK_MARK_GAP],
+        "paperTypes": [
+            LabelType.WITH_GAPS,
+            LabelType.HEAT_SHRINK_TUBE,
+            LabelType.TRANSPARENT,
+            LabelType.BLACK_MARK_GAP,
+            LabelType.CONTINUOUS,
+        ],
     },
     {
         "model": PrinterModel.TP2M_H,
@@ -188,7 +194,7 @@ modelsLibrary: list[PrinterModelMeta] = [
         "dpi": 300,
         "printDirection": PrintDirection.TOP,
         "printheadPixels": 567,
-        "paperTypes": [LabelType.WITH_GAPS, LabelType.BLACK, LabelType.CONTINUOUS, LabelType.TRANSPARENT],
+        "paperTypes": [LabelType.WITH_GAPS, LabelType.BLACK, LabelType.TRANSPARENT],
     },
     {
         "model": PrinterModel.B2,
@@ -197,7 +203,7 @@ modelsLibrary: list[PrinterModelMeta] = [
         "dpi": 203,
         "printDirection": PrintDirection.TOP,
         "printheadPixels": 384,
-        "paperTypes": [LabelType.WITH_GAPS, LabelType.BLACK, LabelType.CONTINUOUS, LabelType.TRANSPARENT],
+        "paperTypes": [LabelType.WITH_GAPS, LabelType.BLACK, LabelType.TRANSPARENT],
     },
     {
         "model": PrinterModel.B18S,
@@ -206,7 +212,13 @@ modelsLibrary: list[PrinterModelMeta] = [
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
         "printheadPixels": 120,
-        "paperTypes": [LabelType.WITH_GAPS, LabelType.TRANSPARENT, LabelType.BLACK_MARK_GAP, LabelType.HEAT_SHRINK_TUBE],
+        "paperTypes": [
+            LabelType.WITH_GAPS,
+            LabelType.TRANSPARENT,
+            LabelType.BLACK_MARK_GAP,
+            LabelType.HEAT_SHRINK_TUBE,
+            LabelType.CONTINUOUS,
+        ],
     },
     {
         "model": PrinterModel.D11_H,
@@ -648,7 +660,13 @@ modelsLibrary: list[PrinterModelMeta] = [
         "dpi": 203,
         "printDirection": PrintDirection.LEFT,
         "printheadPixels": 120,
-        "paperTypes": [LabelType.WITH_GAPS, LabelType.TRANSPARENT, LabelType.BLACK_MARK_GAP, LabelType.HEAT_SHRINK_TUBE],
+        "paperTypes": [
+            LabelType.WITH_GAPS,
+            LabelType.TRANSPARENT,
+            LabelType.BLACK_MARK_GAP,
+            LabelType.HEAT_SHRINK_TUBE,
+            LabelType.CONTINUOUS,
+        ],
     },
     {
         "model": PrinterModel.D11,

--- a/docs/device-info.md
+++ b/docs/device-info.md
@@ -263,35 +263,40 @@ Connection Sound switch.
 
 ## 7. Other state commands
 
-**(not implemented here)** — listed so they are not mistaken for gaps in the protocol.
+Calibration / maintenance buttons implemented by this integration; remaining rows are still unused.
 
 | Command | ID | Notes |
 | --- | --- | --- |
-| PrinterReset | `0x28` | Clears settings such as sound. Response `0x38` |
-| CalibrateHeight | `0x59` | Response `0x69` |
-| LabelPositioningCalibration | `0x8E` | Response `0x8F`, `data[0] == 1` on success. Values 1–2 make B1 eject roughly 15 cm of paper |
-| PrintTestPage | `0x5A` | Response `0x6A` |
-| PrinterLog | `0x05` | Response `0x06` |
-| GetKeyFunction | `0x09` | Hardware button mapping, response `0x0A` |
-| GetPrintQuality | `0x0D` | Request and response share the ID |
-| GetCurrentTimeFormat | `0x12` | Response `0x11` |
-| AntiFake | `0x0B` | Genuine-consumable check. `01` long form, `02` short form. Response `0x0C` |
+| PrinterReset | `0x28` | Clears settings such as sound. Response `0x38`. Reset Printer Settings button |
+| CalibrateHeight | `0x59` | Response `0x69`. Calibrate Roll Feed button |
+| LabelPositioningCalibration | `0x8E` | Response `0x8F`, `data[0] == 1` on success. Values 1–2 make B1 eject roughly 15 cm of paper. Calibrate Label Offset button |
+| PrintTestPage | `0x5A` | Response `0x6A`. Print Test Page button |
+| CancelPrint | `0xDA` | Response `0xD0`. Cancel Print button (enabled while a job is running) |
+| PrinterLog | `0x05` | Response `0x06`. **(not implemented here)** |
+| GetKeyFunction | `0x09` | Hardware button mapping, response `0x0A`. **(not implemented here)** |
+| GetPrintQuality | `0x0D` | Request and response share the ID. **(not implemented here)** |
+| GetCurrentTimeFormat | `0x12` | Response `0x11`. **(not implemented here)** |
+| AntiFake | `0x0B` | Genuine-consumable check. `01` long form, `02` short form. Response `0x0C`. **(not implemented here)** |
 
 ## 8. What this integration exposes
 
-Read at every coordinator refresh:
+Read at every coordinator refresh (and after prints where noted):
 
 | Entity source | Command |
 | --- | --- |
 | Model, serial, software/hardware version | `PrinterInfo` keys 8, 11, 9, 12 |
-| Battery level | `PrinterInfo` key 10 |
-| Lid closed, paper present, RFID readable | `Heartbeat` Advanced1 |
+| Density, speed, label type, auto shutdown, battery bucket, print area | `PrinterInfo` keys 1–3, 7, 10, 15 (cached) |
+| Protocol version, colour support | `PrinterStatusData` (`0xA5`) |
+| Lid/cover, paper, RFID readable, battery | `Heartbeat` Advanced1 (`0x01` → `0xDD`) |
+| Temperature, ribbon, WiFi RSSI, voltage (when present) | `Heartbeat` Advanced2 (`0x04` → `0xD9`) on protocol ≥ 3 |
+| Label / ribbon consumable sensors | `RfidInfo` / `RfidInfo2` when the model supports RFID |
+| Print progress | `PrintStatus` (`0xA3`) and unsolicited `0xE0` during jobs |
 
-Known gaps:
+Print sequence selection uses model `generation` metadata, with `PrinterStatusData` protocol version as a fallback for unknown models (V5 vs V4).
 
-- Heartbeat Advanced2 is never requested, so temperature, ribbon state, WiFi RSSI and voltage are
-  unavailable even on models that report them.
-- `PrinterStatusData` (`0xA5`) is never sent, so protocol version and colour support are unknown, and
-  the print sequence is chosen from the model ID table instead.
-- `pageFeedProgress` is merged into a single progress value.
-- RFID tag contents are read by `get_rfid()` but not surfaced as entities. See [rfid.md](rfid.md).
+Remaining gaps:
+
+- `pageFeedProgress` is still merged into a single progress value for the Print Progress sensor.
+- Colour / greyscale printing is unsupported even when Colour Support is reported.
+- Several information commands in section 7 remain unused (`PrinterLog`, `AntiFake`, …).
+- Optional cloud label lookup (`getCloudTemplateByOneCode`) is off by default.

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -14,8 +14,8 @@ Related: [protocol.md](protocol.md) · [device-info.md](device-info.md) · [prin
 - **Density** — the range accepted by `SetDensity` (`0x21`). `set_label_density` validates against the
   model's own range, which is populated from this table.
 - **Label types** — the values accepted by `SetLabelType` (`0x23`). Exposed as the `label_type`
-  parameter of the print service, validated as 1–11; the model's `paperTypes` is not enforced yet, so
-  an unsupported value reaches the printer and comes back as `SetPrintLabelMaterialNoSupport`.
+  parameter of the print service and validated against the model's `paperTypes` before the job
+  starts (unsupported values raise locally instead of reaching the printer).
 - **RFID** — tag class; see [rfid.md](rfid.md#1-checking-support-first).
 - **IDs in the 51xxx, 52xxx and 53xxx ranges** are rebadged third-party hardware that speaks a
   different protocol. The commands documented here do not apply to them.

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -265,11 +265,10 @@ bytes.
 
 ## 7. Known limitations of this integration
 
-- `SetLabelType` is a print-service parameter validated as 1–11, but it is not checked against the
-  model's own `paperTypes`, so an unsupported value is rejected by the printer instead of locally.
-- `CancelPrint` (`0xDA`) and the 2-byte and 13-byte page-size variants are unimplemented.
+- `SetLabelType` is validated against the model's `paperTypes` before the job starts.
 - Colour and greyscale printing are unsupported. `pageColor` is always `0` and rendering is 1-bit,
   even on models whose Colour Support sensor reports otherwise.
 - Print margins are ignored. The vendor publishes a per-model, per-paper-type `blindZone`, and
   rendering edge to edge can clip near the leading edge on black-mark stock.
-- Flow control is static. Per-write latency is measured but not used to adapt the batch size.
+- The 2-byte and 13-byte `SetPageSize` variants are unused (4 / 6 / 9-byte forms cover current
+  generations).

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -161,7 +161,7 @@ sent before the page was started — not only for physical faults.
 | `0x86` | PrinterCheckLine | `0xD3` | `u16` line + `01` | Mid-transfer checkpoint, every 200 rows |
 | `0xE3` | PageEnd | `0xE4` | `01` | |
 | `0xF3` | PrintEnd | `0xF4` | `01` | `data[0] == 0` means refused |
-| `0xDA` | CancelPrint | `0xD0` | `01` | **(not implemented here)** |
+| `0xDA` | CancelPrint | `0xD0` | `01` | Cancel Print button |
 
 ### 4.2 Settings
 
@@ -170,10 +170,10 @@ sent before the page was started — not only for physical faults.
 | `0x21` | SetDensity | `0x31` | `u8` | Range is per model, see [devices.md](devices.md) |
 | `0x23` | SetLabelType | `0x33` | `u8` | Label type, section 6 |
 | `0x27` | SetAutoShutdownTime | `0x37` | `u8` 1–4 | Auto Shutdown select entity |
-| `0x28` | PrinterReset | `0x38` | `01` | Resets settings such as sound. **(not implemented here)** |
+| `0x28` | PrinterReset | `0x38` | `01` | Resets settings such as sound. Reset Printer Settings button |
 | `0x58` | SoundSettings | `0x68` | `category`, `item`, `value` | Connection Sound switch (get/set) |
-| `0x59` | CalibrateHeight | `0x69` | `01` | **(not implemented here)** |
-| `0x8E` | LabelPositioningCalibration | `0x8F` | `u8` | Feeds ~15 cm on B1 for values 1–2. **(not implemented here)** |
+| `0x59` | CalibrateHeight | `0x69` | `01` | Calibrate Roll Feed button |
+| `0x8E` | LabelPositioningCalibration | `0x8F` | `u8` | Feeds ~15 cm on B1 for values 1–2. Calibrate Label Offset button |
 
 ### 4.3 Information
 
@@ -191,7 +191,7 @@ sent before the page was started — not only for physical faults.
 | `0x0D` | GetPrintQuality | `0x0D` | `01` | Request and response share an ID. **(not implemented here)** |
 | `0x12` | GetCurrentTimeFormat | `0x11` | `01` | **(not implemented here)** |
 | `0xAF` | PrinterConfig | `0xBF` | `01` | **(not implemented here)** |
-| `0x5A` | PrintTestPage | `0x6A` | `01` | **(not implemented here)** |
+| `0x5A` | PrintTestPage | `0x6A` | `01` | Print Test Page button |
 
 ### 4.4 RFID
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,33 @@
+import dataclasses
 import sys
+from typing import Any
 from unittest.mock import MagicMock
 
-# Base class mock supporting subscripting (e.g., BaseClass[T])
+# Base class mock supporting subclassing and subscripting (e.g. BaseClass[T])
 class MockBase:
     def __init__(self, *args, **kwargs):
         pass
+
     def __class_getitem__(cls, item):
         return cls
+
+
+def _make_entity_base(name: str):
+    return type(name, (MockBase,), {})
+
+
+@dataclasses.dataclass(frozen=True)
+class _EntityDescriptionStub:
+    key: str = ""
+    translation_key: str | None = None
+    icon: str | None = None
+    entity_category: Any = None
+    device_class: Any = None
+    state_class: Any = None
+    native_unit_of_measurement: str | None = None
+    entity_registry_enabled_default: bool = True
+    name: str | None = None
+    has_entity_name: bool = False
 
 # ── Mock Home Assistant Modules ────────────────────────────────────────────────
 
@@ -30,6 +51,11 @@ sys.modules["homeassistant.components"] = MagicMock()
 sys.modules["homeassistant.components.recorder.history"] = MagicMock()
 sys.modules["homeassistant.components.bluetooth"] = MagicMock()
 sys.modules["homeassistant.components.image"] = MagicMock()
+sys.modules["homeassistant.components.sensor"] = MagicMock()
+sys.modules["homeassistant.components.binary_sensor"] = MagicMock()
+sys.modules["homeassistant.components.button"] = MagicMock()
+sys.modules["homeassistant.components.switch"] = MagicMock()
+sys.modules["homeassistant.components.select"] = MagicMock()
 
 # Setup bluetooth passive update processor mocks
 ha_bt_processor = MagicMock()
@@ -42,12 +68,64 @@ sys.modules["homeassistant.const"] = MagicMock()
 sys.modules["homeassistant.core"] = MagicMock()
 sys.modules["homeassistant.helpers"] = MagicMock()
 sys.modules["homeassistant.helpers.device_registry"] = MagicMock()
+sys.modules["homeassistant.helpers.entity"] = MagicMock()
+sys.modules["homeassistant.helpers.entity_platform"] = MagicMock()
+sys.modules["homeassistant.helpers.event"] = MagicMock()
+sys.modules["homeassistant.helpers.typing"] = MagicMock()
 sys.modules["homeassistant.helpers.update_coordinator"] = MagicMock()
 sys.modules["homeassistant.helpers.debounce"] = MagicMock()
 sys.modules["homeassistant.helpers.storage"] = MagicMock()
 sys.modules["homeassistant.helpers.aiohttp_client"] = MagicMock()
 sys.modules["homeassistant.util"] = MagicMock()
 sys.modules["homeassistant.util.dt"] = MagicMock()
+
+# Platform entity bases must support subclassing / subscripting, and each
+# class used in a multiple-inheritance MRO must be a distinct type.
+for _mod_name, _attrs in (
+    (
+        "homeassistant.components.sensor",
+        {
+            "SensorEntity": _make_entity_base("SensorEntity"),
+            "SensorEntityDescription": _EntityDescriptionStub,
+            "SensorDeviceClass": MagicMock(),
+            "SensorStateClass": MagicMock(),
+        },
+    ),
+    (
+        "homeassistant.components.binary_sensor",
+        {
+            "BinarySensorEntity": _make_entity_base("BinarySensorEntity"),
+            "BinarySensorEntityDescription": _EntityDescriptionStub,
+            "BinarySensorDeviceClass": MagicMock(),
+        },
+    ),
+    (
+        "homeassistant.components.button",
+        {"ButtonEntity": _make_entity_base("ButtonEntity")},
+    ),
+    (
+        "homeassistant.components.switch",
+        {"SwitchEntity": _make_entity_base("SwitchEntity")},
+    ),
+    (
+        "homeassistant.components.select",
+        {"SelectEntity": _make_entity_base("SelectEntity")},
+    ),
+    (
+        "homeassistant.components.image",
+        {"ImageEntity": _make_entity_base("ImageEntity")},
+    ),
+    (
+        "homeassistant.helpers.update_coordinator",
+        {
+            "CoordinatorEntity": _make_entity_base("CoordinatorEntity"),
+            "DataUpdateCoordinator": _make_entity_base("DataUpdateCoordinator"),
+        },
+    ),
+):
+    _mod = sys.modules[_mod_name]
+    for _attr, _value in _attrs.items():
+        setattr(_mod, _attr, _value)
 
 # ── Mock External Modules ─────────────────────────────────────────────────────
 

--- a/tests/test_label_type_validation.py
+++ b/tests/test_label_type_validation.py
@@ -52,6 +52,19 @@ def test_get_supported_label_type_codes():
     meta_a1_pro = get_printer_meta_by_id(7424)
     assert get_supported_label_type_codes(meta_a1_pro) == [4, 3]
 
+    # N1 / B18 / B18S must include Continuous (3) — vendor DB includes it; T7
+    # rejects unsupported codes locally, so a missing entry is a user-visible
+    # regression.
+    for model_id in (3584, 3585, 3586):
+        codes = get_supported_label_type_codes(get_printer_meta_by_id(model_id))
+        assert 3 in codes, f"model {model_id} missing Continuous"
+
+    # B2 / B2 Pro must not advertise Continuous (vendor DB has Gap/Black/Transparent only).
+    for model_id in (6912, 6913):
+        codes = get_supported_label_type_codes(get_printer_meta_by_id(model_id))
+        assert 3 not in codes, f"model {model_id} should not list Continuous"
+        assert codes == [1, 2, 5]
+
     # Unknown model: every known code is returned (never reject what the printer may accept)
     fallback = get_supported_label_type_codes(None)
     assert 1 in fallback

--- a/tests/test_platform_imports.py
+++ b/tests/test_platform_imports.py
@@ -1,0 +1,34 @@
+"""Smoke imports for Home Assistant platform modules."""
+
+import importlib
+
+import pytest
+
+
+PLATFORM_MODULES = (
+    "custom_components.niimbot.sensor",
+    "custom_components.niimbot.binary_sensor",
+    "custom_components.niimbot.button",
+    "custom_components.niimbot.switch",
+    "custom_components.niimbot.select",
+    "custom_components.niimbot.image",
+)
+
+
+@pytest.mark.parametrize("module_name", PLATFORM_MODULES)
+def test_platform_module_imports(module_name: str) -> None:
+    """Platform modules must import under the conftest HA stubs."""
+    mod = importlib.import_module(module_name)
+    assert hasattr(mod, "async_setup_entry")
+
+
+def test_button_module_defines_action_entities() -> None:
+    button = importlib.import_module("custom_components.niimbot.button")
+    for name in (
+        "NiimbotCancelPrintButton",
+        "NiimbotPrinterResetButton",
+        "NiimbotCalibrateHeightButton",
+        "NiimbotCalibrateLabelPositionButton",
+        "NiimbotPrintTestPageButton",
+    ):
+        assert hasattr(button, name), f"missing {name}"


### PR DESCRIPTION
## Summary
- Align `paperTypes` with the vendor DB: add Continuous for N1/B18/B18S (fixes T7 rejecting a supported label type), remove Continuous from B2/B2 Pro
- Update `protocol.md` / `device-info.md` / `printing.md` / `devices.md` so T2·T4·T6 implemented commands are no longer marked as gaps
- Add HA platform import smoke tests via conftest stubs (sensor/binary_sensor/button/switch/select/image)

## Test plan
- [ ] `PYTHONPATH=. pytest tests/ -q` (93 passed locally)
- [ ] N1/B18 continuous `label_type=3` is accepted; B2 continuous is rejected locally
- [ ] Skim device-info §7–§8 and protocol command table for accuracy


Made with [Cursor](https://cursor.com)