### PR TITLE
Fix WiFi RSSI unit import crash on setup

### DIFF
--- a/custom_components/niimbot/sensor.py
+++ b/custom_components/niimbot/sensor.py
@@ -14,7 +14,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     PERCENTAGE,
-    SIGNAL_STRENGTH_DECIBELS_MILLIWATTS,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
     UnitOfTime,
 )
@@ -194,7 +194,7 @@ ADVANCED2_SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
         key="wifi_rssi",
         translation_key="wifi_rssi",
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATTS,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:wifi",


### PR DESCRIPTION
## Summary
- Replace typo `SIGNAL_STRENGTH_DECIBELS_MILLIWATTS` with HA's `SIGNAL_STRENGTH_DECIBELS_MILLIWATT` so sensor platform import succeeds

## Test plan
- [ ] Reload Niimbot integration; setup no longer fails on ImportError
- [ ] WiFi RSSI diagnostic sensor (when Advanced2) uses dBm


Made with [Cursor](https://cursor.com)