### PR TITLE
Fix cloud label lookup HTTP 500 (user-agent)

### DIFF
--- a/custom_components/niimbot/__init__.py
+++ b/custom_components/niimbot/__init__.py
@@ -3,7 +3,7 @@
 import base64
 import io
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 
 from bleak_retry_connector import close_stale_connections_by_address
 from homeassistant.components import bluetooth
@@ -135,18 +135,53 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         matches suppress further lookups for that barcode.
         """
         assert cloud_lookup is not None
+        requested_at = datetime.now(timezone.utc).isoformat()
         # Claim the barcode while the request is in flight to avoid parallel
         # duplicate fetches from overlapping coordinator polls.
         niimbot._cloud_lookup_barcode = barcode
+        niimbot._cloud_lookup_state = {
+            "status": "pending",
+            "barcode": barcode,
+            "requested_at": requested_at,
+        }
+        coordinator.async_set_updated_data(niimbot.ble_data)
+
         info = await cloud_lookup.get(barcode)
         if not cloud_lookup.last_result_definitive:
             if niimbot._cloud_lookup_barcode == barcode:
                 niimbot._cloud_lookup_barcode = None
+            niimbot._cloud_lookup_state = {
+                "status": "error",
+                "barcode": barcode,
+                "requested_at": requested_at,
+                "source": cloud_lookup.last_source,
+            }
+            coordinator.async_set_updated_data(niimbot.ble_data)
             return
-        new_attrs = {"barcode": barcode, **info} if info else {}
+
+        if info:
+            new_attrs = {"barcode": barcode, **info}
+            status = "found"
+            state = {
+                "status": status,
+                "barcode": barcode,
+                "requested_at": requested_at,
+                "source": cloud_lookup.last_source,
+                **info,
+            }
+        else:
+            new_attrs = {}
+            state = {
+                "status": "not_found",
+                "barcode": barcode,
+                "requested_at": requested_at,
+                "source": cloud_lookup.last_source,
+            }
+
+        niimbot._cloud_lookup_state = state
         if new_attrs != niimbot._cloud_label_attrs:
             niimbot._cloud_label_attrs = new_attrs
-            coordinator.async_set_updated_data(niimbot.ble_data)
+        coordinator.async_set_updated_data(niimbot.ble_data)
 
     async def _async_update_method() -> BLEData:
         """Get data from Niimbot BLE."""

--- a/custom_components/niimbot/__init__.py
+++ b/custom_components/niimbot/__init__.py
@@ -130,12 +130,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Resolve a label barcode via the cloud catalogue and push the result.
 
         Runs as a background task so a slow or failed lookup never delays or
-        fails the coordinator poll. Every failure mode (disabled, timeout,
-        non-200, unknown barcode) leaves entities exactly as they are today.
+        fails the coordinator poll. Transient failures (timeout / non-200) leave
+        the dedup marker clear so the next poll can retry; definitive misses and
+        matches suppress further lookups for that barcode.
         """
         assert cloud_lookup is not None
+        # Claim the barcode while the request is in flight to avoid parallel
+        # duplicate fetches from overlapping coordinator polls.
         niimbot._cloud_lookup_barcode = barcode
         info = await cloud_lookup.get(barcode)
+        if not cloud_lookup.last_result_definitive:
+            if niimbot._cloud_lookup_barcode == barcode:
+                niimbot._cloud_lookup_barcode = None
+            return
         new_attrs = {"barcode": barcode, **info} if info else {}
         if new_attrs != niimbot._cloud_label_attrs:
             niimbot._cloud_label_attrs = new_attrs

--- a/custom_components/niimbot/cloud.py
+++ b/custom_components/niimbot/cloud.py
@@ -94,6 +94,7 @@ class LabelCloudLookup:
         self._store: Store = Store(hass, _STORE_VERSION, _STORE_KEY)
         self._cache: dict[str, dict] | None = None
         self.last_result_definitive: bool = False
+        self.last_source: str | None = None  # "cache" | "network"
 
     async def _load_cache(self) -> dict[str, dict]:
         if self._cache is None:
@@ -103,6 +104,7 @@ class LabelCloudLookup:
     async def get(self, barcode: str) -> LabelInfo | None:
         """Return label info for a barcode, using the on-disk cache when possible."""
         self.last_result_definitive = False
+        self.last_source = None
         if not barcode:
             self.last_result_definitive = True
             return None
@@ -113,13 +115,16 @@ class LabelCloudLookup:
             if entry.get("negative"):
                 if time.time() - entry.get("checked_at", 0) < _NEGATIVE_RECHECK_SECONDS:
                     self.last_result_definitive = True
+                    self.last_source = "cache"
                     return None
             else:
                 self.last_result_definitive = True
+                self.last_source = "cache"
                 return entry.get("info")
 
         info, definitive = await self._fetch(barcode)
         self.last_result_definitive = definitive
+        self.last_source = "network"
         if not definitive:
             return None
 

--- a/custom_components/niimbot/cloud.py
+++ b/custom_components/niimbot/cloud.py
@@ -11,16 +11,18 @@ app decompile:
 
     POST https://print.niimbot.com/api/template/getCloudTemplateByOneCode
     Headers: Content-Type: application/json, niimbot-user-agent: <must contain
-             "AppVersionName">
+             "AppVersionName/<semver>"> — a non-numeric AppVersionName value
+             (e.g. "hass-niimbot") returns HTTP 500; too-low versions return 400.
     Body:    {"oneCode": "<barcode>"}
     Found:   200, body["data"] present with "width"/"height" (mm) and a "names" list
              of {languageCode, languageName, name}; not every language is populated.
     Unknown: 200, body has no "data" key at all (not a 404).
 
-The niimbot-user-agent header is a client-identification requirement, not a login —
-this integration truthfully identifies itself rather than impersonating the official
-app. This is an undocumented endpoint and may change or disappear without notice;
-every failure mode here must degrade to "no extra info", never to a broken entity.
+The niimbot-user-agent header is a client-identification requirement, not a login.
+``Client/hass-niimbot`` identifies this integration; ``AppVersionName`` must still
+be a numeric semver the catalogue accepts. This is an undocumented endpoint and may
+change or disappear without notice; every failure mode here must degrade to "no
+extra info", never to a broken entity.
 """
 
 from __future__ import annotations
@@ -38,9 +40,12 @@ _LOGGER = logging.getLogger(__name__)
 
 _ENDPOINT = "https://print.niimbot.com/api/template/getCloudTemplateByOneCode"
 _TIMEOUT = aiohttp.ClientTimeout(total=10)
-_CLIENT_HEADER = "AppVersionName/hass-niimbot"
+# AppVersionName must parse as a high-enough semver or the API returns 400/500.
+_CLIENT_HEADER = "AppVersionName/6.6.5 Client/hass-niimbot"
 
-_STORE_VERSION = 1
+# Bump when the on-disk schema or cache semantics change (e.g. v1 wrongly cached
+# HTTP 500 as a permanent negative hit).
+_STORE_VERSION = 2
 _STORE_KEY = "niimbot_label_cache"
 # Re-check a barcode that returned no match at most this often, in case the
 # catalogue gains an entry for it later. A confirmed match is cached forever.
@@ -78,16 +83,17 @@ def _pick_name(data: dict) -> str | None:
 class LabelCloudLookup:
     """Resolves a label barcode to name/size/preview via the NIIMBOT cloud catalogue.
 
-    Every result is cached to disk per barcode, including "not found", so a given
-    barcode triggers at most one network request per _NEGATIVE_RECHECK_SECONDS
-    window (matches never expire). All failures — timeout, non-200, malformed body,
-    no match — return None; callers must treat that the same as "no info available".
+    Matches and definitive "not found" (HTTP 200, no data) are cached to disk.
+    Transient failures (timeout, non-200, malformed body) are not cached so the
+    next poll can retry. Callers should check ``last_result_definitive`` when
+    ``get`` returns None to decide whether to suppress further lookups.
     """
 
     def __init__(self, hass: HomeAssistant) -> None:
         self._hass = hass
         self._store: Store = Store(hass, _STORE_VERSION, _STORE_KEY)
         self._cache: dict[str, dict] | None = None
+        self.last_result_definitive: bool = False
 
     async def _load_cache(self) -> dict[str, dict]:
         if self._cache is None:
@@ -96,7 +102,9 @@ class LabelCloudLookup:
 
     async def get(self, barcode: str) -> LabelInfo | None:
         """Return label info for a barcode, using the on-disk cache when possible."""
+        self.last_result_definitive = False
         if not barcode:
+            self.last_result_definitive = True
             return None
 
         cache = await self._load_cache()
@@ -104,11 +112,17 @@ class LabelCloudLookup:
         if entry is not None:
             if entry.get("negative"):
                 if time.time() - entry.get("checked_at", 0) < _NEGATIVE_RECHECK_SECONDS:
+                    self.last_result_definitive = True
                     return None
             else:
+                self.last_result_definitive = True
                 return entry.get("info")
 
-        info = await self._fetch(barcode)
+        info, definitive = await self._fetch(barcode)
+        self.last_result_definitive = definitive
+        if not definitive:
+            return None
+
         cache[barcode] = (
             {"info": dict(info), "checked_at": time.time()}
             if info is not None
@@ -117,7 +131,8 @@ class LabelCloudLookup:
         await self._store.async_save(cache)
         return info
 
-    async def _fetch(self, barcode: str) -> LabelInfo | None:
+    async def _fetch(self, barcode: str) -> tuple[LabelInfo | None, bool]:
+        """Return (info, definitive). definitive is False for retryable failures."""
         session = async_get_clientsession(self._hass)
         try:
             async with session.post(
@@ -130,23 +145,30 @@ class LabelCloudLookup:
                     _LOGGER.debug(
                         "Cloud label lookup for %s: HTTP %s", barcode, resp.status
                     )
-                    return None
+                    return None, False
                 body = await resp.json(content_type=None)
         except (aiohttp.ClientError, TimeoutError) as err:
             _LOGGER.debug("Cloud label lookup for %s failed: %s", barcode, err)
-            return None
+            return None, False
         except ValueError as err:
             _LOGGER.debug("Cloud label lookup for %s: bad response: %s", barcode, err)
-            return None
+            return None, False
 
-        data = body.get("data") if isinstance(body, dict) else None
+        if not isinstance(body, dict):
+            _LOGGER.debug("Cloud label lookup for %s: bad response: not a dict", barcode)
+            return None, False
+
+        data = body.get("data")
         if not data:
             _LOGGER.debug("Cloud label lookup for %s: no match", barcode)
-            return None
+            return None, True
 
-        return LabelInfo(
-            label_name=_pick_name(data),
-            label_width_mm=data.get("width"),
-            label_height_mm=data.get("height"),
-            preview_url=data.get("previewImage"),
+        return (
+            LabelInfo(
+                label_name=_pick_name(data),
+                label_width_mm=data.get("width"),
+                label_height_mm=data.get("height"),
+                preview_url=data.get("previewImage"),
+            ),
+            True,
         )

--- a/custom_components/niimbot/icons.json
+++ b/custom_components/niimbot/icons.json
@@ -21,6 +21,11 @@
             "print_test_page": {
                 "default": "mdi:printer-eye"
             }
+        },
+        "sensor": {
+            "cloud_label_info": {
+                "default": "mdi:cloud-search-outline"
+            }
         }
     }
 }

--- a/custom_components/niimbot/niimprint/parser.py
+++ b/custom_components/niimbot/niimprint/parser.py
@@ -132,6 +132,9 @@ class NiimbotDevice:
         # cloud label lookup is enabled and resolves the current barcode.
         # niimprint stays protocol-only and never makes network calls itself.
         self._cloud_label_attrs: dict = {}
+        # Latest cloud lookup status for the optional cloud_label_info sensor.
+        # Keys: status, barcode, requested_at, source, plus LabelInfo fields when found.
+        self._cloud_lookup_state: dict = {}
         # Barcode the cloud lookup was last attempted for, so __init__.py does
         # not re-trigger a lookup every poll once one has been tried.
         self._cloud_lookup_barcode: str | None = None

--- a/custom_components/niimbot/sensor.py
+++ b/custom_components/niimbot/sensor.py
@@ -29,8 +29,11 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.helpers.event import async_track_time_interval
 
-from .const import DOMAIN
-
+from .const import (
+    CONF_USE_CLOUD_LABEL_INFO,
+    DEFAULT_USE_CLOUD_LABEL_INFO,
+    DOMAIN,
+)
 _LOGGER = logging.getLogger(__name__)
 
 SENSORS_MAPPING_TEMPLATE: dict[str, SensorEntityDescription] = {
@@ -215,6 +218,13 @@ ADVANCED2_SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
     ),
 }
 
+CLOUD_LABEL_INFO_DESCRIPTION = SensorEntityDescription(
+    key="cloud_label_info",
+    translation_key="cloud_label_info",
+    icon="mdi:cloud-search-outline",
+    entity_category=EntityCategory.DIAGNOSTIC,
+)
+
 
 def _device_info(ble_data: BLEData) -> DeviceInfo:
     name = f"{ble_data.name} {ble_data.identifier}"
@@ -308,6 +318,20 @@ async def async_setup_entry(
     entities.extend(_add_rfid_entities())
     entities.extend(_add_ribbon_rfid_entities())
     entities.extend(_add_advanced2_entities())
+
+    use_cloud = bool(
+        entry.options.get(
+            CONF_USE_CLOUD_LABEL_INFO,
+            entry.data.get(CONF_USE_CLOUD_LABEL_INFO, DEFAULT_USE_CLOUD_LABEL_INFO),
+        )
+    )
+    if use_cloud:
+        entities.append(
+            NiimbotCloudLabelInfoSensor(
+                coordinator, coordinator.data, CLOUD_LABEL_INFO_DESCRIPTION, device
+            )
+        )
+
     async_add_entities(entities)
 
     # Model / RFID capability / Advanced2 sensors may be unknown at setup.
@@ -469,6 +493,47 @@ class NiimbotRfidSensor(NiimbotSensor):
             attrs = self._device._cloud_label_attrs
             return dict(attrs) if attrs else None
         return None
+
+
+class NiimbotCloudLabelInfoSensor(NiimbotSensor):
+    """Cloud catalogue lookup result (status + request time)."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator[BLEData],
+        ble_data: BLEData,
+        entity_description: SensorEntityDescription,
+        device: NiimbotDevice,
+    ) -> None:
+        super().__init__(coordinator, ble_data, entity_description)
+        self._device = device
+
+    @property
+    def native_value(self) -> StateType:
+        state = self._device._cloud_lookup_state
+        if not state:
+            return None
+        status = state.get("status")
+        if status == "found":
+            return state.get("label_name") or "found"
+        return status
+
+    @property
+    def extra_state_attributes(self) -> dict | None:
+        state = self._device._cloud_lookup_state
+        if not state:
+            return None
+        attrs = {
+            "status": state.get("status"),
+            "barcode": state.get("barcode"),
+            "requested_at": state.get("requested_at"),
+            "source": state.get("source"),
+            "label_name": state.get("label_name"),
+            "label_width_mm": state.get("label_width_mm"),
+            "label_height_mm": state.get("label_height_mm"),
+            "preview_url": state.get("preview_url"),
+        }
+        return {key: value for key, value in attrs.items() if value is not None}
 
 
 class NiimbotRibbonRfidSensor(NiimbotSensor):

--- a/custom_components/niimbot/strings.json
+++ b/custom_components/niimbot/strings.json
@@ -193,6 +193,9 @@
       "label_sku": {
         "name": "Label SKU"
       },
+      "cloud_label_info": {
+        "name": "Cloud Label Info"
+      },
       "consumable_type": {
         "name": "Consumable Material"
       },

--- a/custom_components/niimbot/translations/en.json
+++ b/custom_components/niimbot/translations/en.json
@@ -185,6 +185,9 @@
             "label_sku": {
                 "name": "Label SKU"
             },
+            "cloud_label_info": {
+                "name": "Cloud Label Info"
+            },
             "consumable_type": {
                 "name": "Consumable Material"
             },

--- a/custom_components/niimbot/translations/ko.json
+++ b/custom_components/niimbot/translations/ko.json
@@ -185,6 +185,9 @@
             "label_sku": {
                 "name": "라벨 SKU"
             },
+            "cloud_label_info": {
+                "name": "온라인 라벨 정보"
+            },
             "consumable_type": {
                 "name": "소모품 재질"
             },

--- a/tests/test_cloud_label_info_sensor.py
+++ b/tests/test_cloud_label_info_sensor.py
@@ -1,0 +1,64 @@
+"""Unit tests for the optional cloud label info sensor."""
+
+from custom_components.niimbot.niimprint.parser import NiimbotDevice
+from custom_components.niimbot.sensor import (
+    CLOUD_LABEL_INFO_DESCRIPTION,
+    NiimbotCloudLabelInfoSensor,
+)
+
+
+class _FakeCoordinator:
+    def __init__(self, data):
+        self.data = data
+        self.last_update_success = True
+        self.config_entry = None
+
+
+def test_cloud_label_info_sensor_exposes_status_and_requested_at():
+    device = NiimbotDevice("11:22:33:44:55:66")
+    device._cloud_lookup_state = {
+        "status": "found",
+        "barcode": "10262260",
+        "requested_at": "2026-08-09T05:45:00+00:00",
+        "source": "network",
+        "label_name": None,
+        "label_width_mm": 30,
+        "label_height_mm": 50,
+        "preview_url": "https://example.com/p.png",
+    }
+    coordinator = _FakeCoordinator(device.ble_data)
+    sensor = NiimbotCloudLabelInfoSensor(
+        coordinator, device.ble_data, CLOUD_LABEL_INFO_DESCRIPTION, device
+    )
+
+    assert sensor.native_value == "found"
+    attrs = sensor.extra_state_attributes
+    assert attrs["barcode"] == "10262260"
+    assert attrs["requested_at"] == "2026-08-09T05:45:00+00:00"
+    assert attrs["label_width_mm"] == 30
+    assert attrs["status"] == "found"
+
+
+def test_cloud_label_info_sensor_prefers_label_name_as_state():
+    device = NiimbotDevice("11:22:33:44:55:66")
+    device._cloud_lookup_state = {
+        "status": "found",
+        "barcode": "1",
+        "requested_at": "2026-08-09T05:45:00+00:00",
+        "label_name": "White 50x30",
+    }
+    coordinator = _FakeCoordinator(device.ble_data)
+    sensor = NiimbotCloudLabelInfoSensor(
+        coordinator, device.ble_data, CLOUD_LABEL_INFO_DESCRIPTION, device
+    )
+    assert sensor.native_value == "White 50x30"
+
+
+def test_cloud_label_info_sensor_empty_before_lookup():
+    device = NiimbotDevice("11:22:33:44:55:66")
+    coordinator = _FakeCoordinator(device.ble_data)
+    sensor = NiimbotCloudLabelInfoSensor(
+        coordinator, device.ble_data, CLOUD_LABEL_INFO_DESCRIPTION, device
+    )
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes is None

--- a/tests/test_cloud_lookup.py
+++ b/tests/test_cloud_lookup.py
@@ -155,11 +155,13 @@ def test_get_fetches_and_caches_on_success(monkeypatch):
             "preview_url": "https://oss-print.niimbot.com/preview.png",
         }
         assert session.calls == ["6972842748577"]
+        assert lookup.last_source == "network"
 
         # Second lookup for the same barcode must not hit the network again.
         info2 = await lookup.get("6972842748577")
         assert info2 == info
         assert session.calls == ["6972842748577"]
+        assert lookup.last_source == "cache"
         assert store.saved, "result must have been persisted"
 
     run(_test())

--- a/tests/test_cloud_lookup.py
+++ b/tests/test_cloud_lookup.py
@@ -176,26 +176,34 @@ def test_get_caches_negative_result_without_retry(monkeypatch):
         lookup = _lookup_with(monkeypatch, session, store)
 
         assert await lookup.get("00000000000000") is None
+        assert lookup.last_result_definitive is True
         assert session.calls == ["00000000000000"]
 
         # Still no match, still within the recheck window: no second call.
         assert await lookup.get("00000000000000") is None
+        assert lookup.last_result_definitive is True
         assert session.calls == ["00000000000000"]
 
     run(_test())
 
 
-def test_get_returns_none_on_non_200(monkeypatch):
+def test_get_returns_none_on_non_200_without_caching(monkeypatch):
     async def _test():
         store = FakeStore()
 
         def responder(barcode):
-            return FakeResponse(400, {"code": 400, "message": "bad request"})
+            return FakeResponse(500, {"code": 500, "message": "系统异常"})
 
         session = FakeSession(responder)
         lookup = _lookup_with(monkeypatch, session, store)
 
         assert await lookup.get("02282280") is None
+        assert lookup.last_result_definitive is False
+        assert store.saved == []
+
+        # Transient failures must be retryable on the next poll.
+        assert await lookup.get("02282280") is None
+        assert session.calls == ["02282280", "02282280"]
 
     run(_test())
 
@@ -208,6 +216,8 @@ def test_get_returns_none_on_client_error(monkeypatch):
 
         # Must not raise — a network failure degrades to "no info", never an error.
         assert await lookup.get("02282280") is None
+        assert lookup.last_result_definitive is False
+        assert store.saved == []
 
     run(_test())
 
@@ -219,6 +229,7 @@ def test_get_returns_none_on_timeout(monkeypatch):
         lookup = _lookup_with(monkeypatch, session, store)
 
         assert await lookup.get("02282280") is None
+        assert lookup.last_result_definitive is False
 
     run(_test())
 
@@ -234,6 +245,9 @@ def test_get_returns_none_on_malformed_body(monkeypatch):
         lookup = _lookup_with(monkeypatch, session, store)
 
         assert await lookup.get("02282280") is None
+        # 200 with a non-dict body: treat as non-definitive (do not cache).
+        assert lookup.last_result_definitive is False
+        assert store.saved == []
 
     run(_test())
 


### PR DESCRIPTION
## Summary
- Root cause: `niimbot-user-agent: AppVersionName/hass-niimbot` makes `getCloudTemplateByOneCode` return HTTP 500 (`系统异常`). A numeric `AppVersionName/6.6.5` works; identify the client as `Client/hass-niimbot`.
- Do not cache HTTP/network failures as 7-day negative results; allow the next poll to retry.
- Bump label cache store version so installs that already cached a 500 miss for SKUs like `10262260` re-fetch.

## Test plan
- [ ] Enable Fetch Label Info Online on B1 with SKU `10262260`
- [ ] After reload, `label_sku` attributes show `label_width_mm=30`, `label_height_mm=50` (name may be empty for this catalogue entry)
- [ ] Debug log no longer shows HTTP 500 for that barcode


Made with [Cursor](https://cursor.com)