### PR TITLE
Hide Print Test Page on B1 (unsupported 0x5A)

### DIFF
--- a/custom_components/niimbot/button.py
+++ b/custom_components/niimbot/button.py
@@ -38,9 +38,12 @@ async def async_setup_entry(
     entities: list[ButtonEntity] = [
         NiimbotCancelPrintButton(coordinator, coordinator.data, device),
         NiimbotPrinterResetButton(coordinator, coordinator.data, device),
-        # Many models (observed: B1) NAK PrintTestPage (0x5A); keep disabled by default.
-        NiimbotPrintTestPageButton(coordinator, coordinator.data, device),
     ]
+
+    if device.supports_print_test_page():
+        entities.append(
+            NiimbotPrintTestPageButton(coordinator, coordinator.data, device)
+        )
 
     if device.supports_calibration():
         entities.append(

--- a/custom_components/niimbot/niimprint/model.py
+++ b/custom_components/niimbot/niimprint/model.py
@@ -963,6 +963,23 @@ def supports_height_calibration(meta: PrinterModelMeta | None) -> bool:
     return LabelType.CONTINUOUS in paper_types
 
 
+# Observed to NAK PrintTestPage (0x5A). No vendor capability flag exists.
+_PRINT_TEST_PAGE_UNSUPPORTED = frozenset(
+    {
+        PrinterModel.B1,
+        PrinterModel.B1_PRO,
+        PrinterModel.B1_SE,
+    }
+)
+
+
+def supports_print_test_page(meta: PrinterModelMeta | None) -> bool:
+    """Return False for models known to reject PrintTestPage (0x5A)."""
+    if meta is None:
+        return False
+    return meta.get("model") not in _PRINT_TEST_PAGE_UNSUPPORTED
+
+
 _LABEL_TYPE_NAMES = {
     1: "WithGaps",
     2: "Black",

--- a/custom_components/niimbot/niimprint/parser.py
+++ b/custom_components/niimbot/niimprint/parser.py
@@ -23,6 +23,7 @@ from .model import (
     supports_calibration,
     supports_height_calibration,
     supports_label_rfid,
+    supports_print_test_page,
     supports_ribbon_rfid,
 )
 from .printer import InfoEnum, PrinterClient, PrinterError, PrinterTimeout, SoundEnum
@@ -193,6 +194,12 @@ class NiimbotDevice:
         if meta is None:
             return False
         return supports_height_calibration(meta)
+
+    def supports_print_test_page(self) -> bool:
+        meta = self.get_model_meta()
+        if meta is None:
+            return False
+        return supports_print_test_page(meta)
 
     def _apply_heartbeat(self, heartbeat: dict) -> None:
         """Apply heartbeat data to sensors."""

--- a/tests/test_button_actions.py
+++ b/tests/test_button_actions.py
@@ -9,6 +9,7 @@ from custom_components.niimbot.niimprint.model import (
     get_printer_meta_by_id,
     supports_calibration,
     supports_height_calibration,
+    supports_print_test_page,
 )
 from custom_components.niimbot.niimprint.packet import NiimbotPacket
 from custom_components.niimbot.niimprint.parser import NiimbotDevice
@@ -26,22 +27,26 @@ def test_supports_calibration_helper():
     assert meta_b1 is not None
     assert supports_calibration(meta_b1) is True
     assert supports_height_calibration(meta_b1) is False
+    assert supports_print_test_page(meta_b1) is False
 
-    # D110 (2304) does not support calibration
+    # D110 (2304) does not support calibration; PrintTestPage not denylisted
     meta_d110 = get_printer_meta_by_id(2304)
     assert meta_d110 is not None
     assert supports_calibration(meta_d110) is False
     assert supports_height_calibration(meta_d110) is False
+    assert supports_print_test_page(meta_d110) is True
 
     # B3 (52993): Continuous + calibration → height calibration gated on
     meta_b3 = get_printer_meta_by_id(52993)
     assert meta_b3 is not None
     assert supports_calibration(meta_b3) is True
     assert supports_height_calibration(meta_b3) is True
+    assert supports_print_test_page(meta_b3) is True
 
     # None meta returns False
     assert supports_calibration(None) is False
     assert supports_height_calibration(None) is False
+    assert supports_print_test_page(None) is False
 
 
 def test_calibrate_label_position_command():


### PR DESCRIPTION
## Summary
- B1 / B1 Pro / B1 SE NAK `PrintTestPage` (`0x5A`); do not create the button on those models
- Avoids the enable-and-fail path that raised \"This printer does not support print test page\"

## Test plan
- [ ] B1: Print Test Page entity is not created after reload (delete any leftover restored entity if shown)
- [ ] Non-B1 model: Print Test Page still appears (disabled by default)


Made with [Cursor](https://cursor.com)