### PR TITLE
Unstick cloud label sensor from pending on errors

### DIFF
--- a/custom_components/niimbot/__init__.py
+++ b/custom_components/niimbot/__init__.py
@@ -146,7 +146,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         }
         coordinator.async_set_updated_data(niimbot.ble_data)
 
-        info = await cloud_lookup.get(barcode)
+        try:
+            info = await cloud_lookup.get(barcode)
+        except Exception as err:  # noqa: BLE001 — never leave the sensor on pending
+            _LOGGER.debug("Cloud label lookup for %s raised: %s", barcode, err)
+            if niimbot._cloud_lookup_barcode == barcode:
+                niimbot._cloud_lookup_barcode = None
+            niimbot._cloud_lookup_state = {
+                "status": "error",
+                "barcode": barcode,
+                "requested_at": requested_at,
+            }
+            coordinator.async_set_updated_data(niimbot.ble_data)
+            return
+
         if not cloud_lookup.last_result_definitive:
             if niimbot._cloud_lookup_barcode == barcode:
                 niimbot._cloud_lookup_barcode = None
@@ -161,9 +174,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         if info:
             new_attrs = {"barcode": barcode, **info}
-            status = "found"
             state = {
-                "status": status,
+                "status": "found",
                 "barcode": barcode,
                 "requested_at": requested_at,
                 "source": cloud_lookup.last_source,


### PR DESCRIPTION
## Summary
- If cloud lookup raises unexpectedly, set status to \`error\` and clear the dedup claim so the next poll can retry (was stuck on \`pending\`)

## Test plan
- [ ] Enable cloud label info; sensor moves pending → found/not_found/error within ~10s
- [ ] Does not remain on pending indefinitely


Made with [Cursor](https://cursor.com)