### PR TITLE
Hide B1 paper calibration (long feed); clarify other models

### DIFF
--- a/custom_components/niimbot/button.py
+++ b/custom_components/niimbot/button.py
@@ -45,7 +45,8 @@ async def async_setup_entry(
             NiimbotPrintTestPageButton(coordinator, coordinator.data, device)
         )
 
-    if device.supports_calibration():
+    # B1-class ACKs 0x8E but feeds ~15 cm; hide there. Other models: paper calibration.
+    if device.supports_label_position_calibration():
         entities.append(
             NiimbotCalibrateLabelPositionButton(coordinator, coordinator.data, device)
         )
@@ -110,7 +111,10 @@ class NiimbotBaseButton(
 
 
 class NiimbotCalibrateLabelPositionButton(NiimbotBaseButton):
-    """Button to calibrate label positioning offset."""
+    """Button to run paper/gap sensor calibration (may feed several labels)."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
 
     def __init__(
         self,
@@ -125,9 +129,9 @@ class NiimbotCalibrateLabelPositionButton(NiimbotBaseButton):
         try:
             ok = await self._device.calibrate_label_position(ble_dev)
             if not ok:
-                raise HomeAssistantError("Printer rejected label position calibration")
+                raise HomeAssistantError("Printer rejected paper calibration")
         except Exception as err:
-            _reraise_action_error("calibrate label position", err)
+            _reraise_action_error("paper calibration", err)
 
 
 class NiimbotCalibrateHeightButton(NiimbotBaseButton):

--- a/custom_components/niimbot/niimprint/model.py
+++ b/custom_components/niimbot/niimprint/model.py
@@ -944,7 +944,7 @@ _DEFAULT_CAPS = (RfidClass.NONE, 1, 5, 3, False)
 
 
 def supports_calibration(meta: PrinterModelMeta | None) -> bool:
-    """Return True if model supports LabelPositioningCalibration (0x8E)."""
+    """Return True if vendor marks the model as supporting paper calibration (0x8E)."""
     if meta is None:
         return False
     return meta.get("isSupportCalibration", False)
@@ -963,8 +963,9 @@ def supports_height_calibration(meta: PrinterModelMeta | None) -> bool:
     return LabelType.CONTINUOUS in paper_types
 
 
-# Observed to NAK PrintTestPage (0x5A). No vendor capability flag exists.
-_PRINT_TEST_PAGE_UNSUPPORTED = frozenset(
+# B1-class: PrintTestPage (0x5A) NAKs; LabelPositioningCalibration (0x8E) ACKs but
+# feeds ~15 cm of paper (unsuitable as a casual HA button).
+_B1_FAMILY = frozenset(
     {
         PrinterModel.B1,
         PrinterModel.B1_PRO,
@@ -973,11 +974,18 @@ _PRINT_TEST_PAGE_UNSUPPORTED = frozenset(
 )
 
 
+def supports_label_position_calibration(meta: PrinterModelMeta | None) -> bool:
+    """Return True if Paper Calibration (0x8E) should be exposed as a button."""
+    if not supports_calibration(meta):
+        return False
+    return meta.get("model") not in _B1_FAMILY
+
+
 def supports_print_test_page(meta: PrinterModelMeta | None) -> bool:
     """Return False for models known to reject PrintTestPage (0x5A)."""
     if meta is None:
         return False
-    return meta.get("model") not in _PRINT_TEST_PAGE_UNSUPPORTED
+    return meta.get("model") not in _B1_FAMILY
 
 
 _LABEL_TYPE_NAMES = {

--- a/custom_components/niimbot/niimprint/parser.py
+++ b/custom_components/niimbot/niimprint/parser.py
@@ -22,6 +22,7 @@ from .model import (
     rfid_supported_on_firmware,
     supports_calibration,
     supports_height_calibration,
+    supports_label_position_calibration,
     supports_label_rfid,
     supports_print_test_page,
     supports_ribbon_rfid,
@@ -188,6 +189,12 @@ class NiimbotDevice:
         if meta is None:
             return False
         return supports_calibration(meta)
+
+    def supports_label_position_calibration(self) -> bool:
+        meta = self.get_model_meta()
+        if meta is None:
+            return False
+        return supports_label_position_calibration(meta)
 
     def supports_height_calibration(self) -> bool:
         meta = self.get_model_meta()
@@ -530,10 +537,15 @@ class NiimbotDevice:
             return self.ble_data
 
     async def calibrate_label_position(self, ble_device: BLEDevice) -> bool:
-        """Calibrate label positioning offset (0x8E)."""
+        """Calibrate paper gap/mark sensors (0x8E), after setting label type."""
         async with self.lock:
             printer = await self._ensure_printer(ble_device)
             try:
+                label_type = self.ble_data.labeltype
+                if label_type is None:
+                    label_type = default_label_type_code(self.get_model_meta())
+                if not await printer.set_label_type(int(label_type)):
+                    return False
                 return await printer.calibrate_label_position()
             finally:
                 await self._release_printer()

--- a/custom_components/niimbot/strings.json
+++ b/custom_components/niimbot/strings.json
@@ -257,7 +257,7 @@
     },
     "button": {
       "calibrate_label_position": {
-        "name": "Calibrate Label Position"
+        "name": "Paper Calibration"
       },
       "calibrate_roll_feed": {
         "name": "Calibrate Roll Feed"

--- a/custom_components/niimbot/translations/en.json
+++ b/custom_components/niimbot/translations/en.json
@@ -249,7 +249,7 @@
         },
         "button": {
             "calibrate_label_position": {
-                "name": "Calibrate Label Position"
+                "name": "Paper Calibration"
             },
             "calibrate_roll_feed": {
                 "name": "Calibrate Roll Feed"

--- a/custom_components/niimbot/translations/ko.json
+++ b/custom_components/niimbot/translations/ko.json
@@ -249,7 +249,7 @@
         },
         "button": {
             "calibrate_label_position": {
-                "name": "라벨 위치 보정"
+                "name": "용지 캘리브레이션"
             },
             "calibrate_roll_feed": {
                 "name": "롤 피드 보정"

--- a/tests/test_button_actions.py
+++ b/tests/test_button_actions.py
@@ -9,6 +9,7 @@ from custom_components.niimbot.niimprint.model import (
     get_printer_meta_by_id,
     supports_calibration,
     supports_height_calibration,
+    supports_label_position_calibration,
     supports_print_test_page,
 )
 from custom_components.niimbot.niimprint.packet import NiimbotPacket
@@ -22,10 +23,11 @@ def run(coro):
 
 
 def test_supports_calibration_helper():
-    # B1 (4096): label-position calibration yes; height (0x59) no Continuous paper
+    # B1 (4096): vendor calibration yes, but HA hides 0x8E (long feed) and 0x5A (NAK)
     meta_b1 = get_printer_meta_by_id(4096)
     assert meta_b1 is not None
     assert supports_calibration(meta_b1) is True
+    assert supports_label_position_calibration(meta_b1) is False
     assert supports_height_calibration(meta_b1) is False
     assert supports_print_test_page(meta_b1) is False
 
@@ -33,18 +35,21 @@ def test_supports_calibration_helper():
     meta_d110 = get_printer_meta_by_id(2304)
     assert meta_d110 is not None
     assert supports_calibration(meta_d110) is False
+    assert supports_label_position_calibration(meta_d110) is False
     assert supports_height_calibration(meta_d110) is False
     assert supports_print_test_page(meta_d110) is True
 
-    # B3 (52993): Continuous + calibration → height calibration gated on
+    # B3 (52993): Continuous + calibration → height and paper calibration exposed
     meta_b3 = get_printer_meta_by_id(52993)
     assert meta_b3 is not None
     assert supports_calibration(meta_b3) is True
+    assert supports_label_position_calibration(meta_b3) is True
     assert supports_height_calibration(meta_b3) is True
     assert supports_print_test_page(meta_b3) is True
 
     # None meta returns False
     assert supports_calibration(None) is False
+    assert supports_label_position_calibration(None) is False
     assert supports_height_calibration(None) is False
     assert supports_print_test_page(None) is False
 
@@ -57,6 +62,38 @@ def test_calibrate_label_position_command():
         assert res is True
         assert len(transport.written_packets) == 1
         assert transport.written_packets[0].type == RequestCodeEnum.LABEL_POSITIONING_CALIBRATION
+
+    run(_test())
+
+
+def test_device_paper_calibration_sets_label_type_first():
+    async def _test():
+        device = NiimbotDevice("aa:bb:cc:dd:ee:ff")
+        device.ble_data.labeltype = 2
+        transport = FakeTransport(
+            [
+                NiimbotPacket(51, b"\x01"),  # set_label_type → 0x23+16
+                NiimbotPacket(143, b"\x01"),  # calibrate → 0x8F
+            ]
+        )
+        client = PrinterClient(transport=transport)
+
+        async def _ensure(_ble):
+            return client
+
+        async def _release():
+            return None
+
+        device._ensure_printer = _ensure  # type: ignore[method-assign]
+        device._release_printer = _release  # type: ignore[method-assign]
+
+        assert await device.calibrate_label_position("aa:bb:cc:dd:ee:ff") is True
+        assert transport.written_packets[0].type == RequestCodeEnum.SET_LABEL_TYPE
+        assert transport.written_packets[0].data == b"\x02"
+        assert (
+            transport.written_packets[1].type
+            == RequestCodeEnum.LABEL_POSITIONING_CALIBRATION
+        )
 
     run(_test())
 


### PR DESCRIPTION
## Summary
- B1 / B1 Pro / B1 SE: do not create Paper Calibration button — \`0x8E\` ACKs but feeds ~15 cm
- Other calibrating models: rename to Paper Calibration, diagnostic + disabled by default, \`SetLabelType\` then \`0x8E\`

## Test plan
- [ ] B1: no Paper Calibration / former Label Position button after reload (delete restored entity if leftover)
- [ ] Non-B1 calibrating model: Paper Calibration present but disabled by default


Made with [Cursor](https://cursor.com)