### PR TITLE
Expand cloud label attributes; auto print size defaults

### DIFF
--- a/custom_components/niimbot/__init__.py
+++ b/custom_components/niimbot/__init__.py
@@ -268,9 +268,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     @callback
     # callback for the draw custom service
     async def printservice(service: ServiceCall) -> ServiceResponse:
+        cloud = niimbot._cloud_label_attrs or {}
+        render_defaults: dict = {}
+        if cloud.get("print_width_px") is not None:
+            render_defaults["width"] = int(cloud["print_width_px"])
+        if cloud.get("print_height_px") is not None:
+            render_defaults["height"] = int(cloud["print_height_px"])
+
         try:
             image = await hass.async_add_executor_job(
-                render_image, entry.entry_id, service, hass
+                render_image, entry.entry_id, service, hass, render_defaults
             )
         except Exception as e:
             raise ServiceValidationError("Failed to create image: %s" % e) from e
@@ -292,9 +299,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # niimbot.get_model_meta() is populated by the coordinator update cycle and
         # is therefore available without BLE.  If the model is not yet known the
         # check is skipped; the fallback inside NiimbotDevice.print_image covers that.
-        requested_label_type = (
-            int(service.data["label_type"]) if "label_type" in service.data else None
-        )
+        if "label_type" in service.data:
+            requested_label_type = int(service.data["label_type"])
+        elif cloud.get("paper_type") is not None:
+            requested_label_type = int(cloud["paper_type"])
+        else:
+            requested_label_type = None
         model_meta = niimbot.get_model_meta()
         if requested_label_type is not None and model_meta is not None:
             supported_types = get_supported_label_type_codes(model_meta)

--- a/custom_components/niimbot/cloud.py
+++ b/custom_components/niimbot/cloud.py
@@ -6,23 +6,9 @@ human-readable name and physical size for the loaded roll. When enabled, only th
 loaded label's product barcode is sent to print.niimbot.com — no serial number, tag
 UUID, MAC address or Home Assistant instance identifier.
 
-Endpoint contract verified manually against the live API (2026-08-09), not from the
-app decompile:
-
-    POST https://print.niimbot.com/api/template/getCloudTemplateByOneCode
-    Headers: Content-Type: application/json, niimbot-user-agent: <must contain
-             "AppVersionName/<semver>"> — a non-numeric AppVersionName value
-             (e.g. "hass-niimbot") returns HTTP 500; too-low versions return 400.
-    Body:    {"oneCode": "<barcode>"}
-    Found:   200, body["data"] present with "width"/"height" (mm) and a "names" list
-             of {languageCode, languageName, name}; not every language is populated.
-    Unknown: 200, body has no "data" key at all (not a 404).
-
-The niimbot-user-agent header is a client-identification requirement, not a login.
-``Client/hass-niimbot`` identifies this integration; ``AppVersionName`` must still
-be a numeric semver the catalogue accepts. This is an undocumented endpoint and may
-change or disappear without notice; every failure mode here must degrade to "no
-extra info", never to a broken entity.
+Parsed catalogue fields feed the Cloud Label Info sensor and, when the print
+service omits width/height/label_type, supply defaults (print_*_px after applying
+the catalogue rotate so the bitmap matches the physical label orientation).
 """
 
 from __future__ import annotations
@@ -30,7 +16,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import TypedDict
+from typing import Any, NotRequired, TypedDict
 
 import aiohttp
 from homeassistant.core import HomeAssistant
@@ -46,41 +32,138 @@ _FETCH_TIMEOUT_SECONDS = 10
 # AppVersionName must parse as a high-enough semver or the API returns 400/500.
 _CLIENT_HEADER = "AppVersionName/6.6.5 Client/hass-niimbot"
 
-# Bump when the on-disk schema or cache semantics change (e.g. v1 wrongly cached
-# HTTP 500 as a permanent negative hit).
-_STORE_VERSION = 2
+# Bump when the on-disk LabelInfo schema changes so stale partial caches re-fetch.
+_STORE_VERSION = 3
 _STORE_KEY = f"{DOMAIN}.label_cache"
-# Re-check a barcode that returned no match at most this often, in case the
-# catalogue gains an entry for it later. A confirmed match is cached forever.
 _NEGATIVE_RECHECK_SECONDS = 7 * 24 * 3600
 
 
 class LabelInfo(TypedDict):
     label_name: str | None
+    catalog_barcode: NotRequired[str | None]
     label_width_mm: float | None
     label_height_mm: float | None
+    label_width_px: NotRequired[int | None]
+    label_height_px: NotRequired[int | None]
+    print_width_px: NotRequired[int | None]
+    print_height_px: NotRequired[int | None]
+    dpi: NotRequired[int | None]
+    paper_type: NotRequired[int | None]
+    consumable_type: NotRequired[int | None]
+    rotate: NotRequired[int | None]
+    canvas_rotate: NotRequired[int | None]
+    margin: NotRequired[list[int] | None]
     preview_url: str | None
+    thumbnail_url: NotRequired[str | None]
+    background_image_url: NotRequired[str | None]
+    content_thumbnail_url: NotRequired[str | None]
+    template_id: NotRequired[int | None]
+    origin_template_id: NotRequired[int | None]
+    version: NotRequired[str | None]
+    commodity_template: NotRequired[bool | None]
+    is_cable: NotRequired[bool | None]
+    cable_direction: NotRequired[int | None]
+    cable_length: NotRequired[float | None]
+    marketing_category_id: NotRequired[int | None]
+    sticky: NotRequired[bool | None]
+    has_vip_res: NotRequired[bool | None]
+    label_names: NotRequired[dict[str, str] | None]
+
+
+def _mm_to_px(mm: Any, dpi: int | None) -> int | None:
+    if mm is None or not dpi:
+        return None
+    try:
+        return max(1, round(float(mm) / 25.4 * int(dpi)))
+    except (TypeError, ValueError):
+        return None
 
 
 def _pick_name(data: dict) -> str | None:
-    """Pick a display name from the per-language list.
+    """Pick a display name from names / labelNames / name.
 
-    Coverage varies by SKU — some entries have every language, some only Chinese.
-    Prefer English, then Korean, then the catalogue's own default name, then
-    whatever is non-empty.
+    Prefer English, then Korean, then any non-empty entry, then ``name``.
     """
-    names = data.get("names") or []
-    by_lang = {
-        entry.get("languageCode"): entry.get("name")
-        for entry in names
-        if entry.get("name")
-    }
+    by_lang: dict[str, str] = {}
+    for entry in list(data.get("names") or []) + list(data.get("labelNames") or []):
+        code = entry.get("languageCode")
+        name = entry.get("name")
+        if code and name:
+            by_lang[code] = name
     for lang in ("en", "ko"):
         if by_lang.get(lang):
             return by_lang[lang]
     if data.get("name"):
         return data["name"]
     return next(iter(by_lang.values()), None)
+
+
+def parse_label_data(data: dict) -> LabelInfo:
+    """Map a catalogue ``data`` object to LabelInfo (no network)."""
+    width_mm = data.get("width")
+    height_mm = data.get("height")
+    dpi_raw = data.get("paccuracyName")
+    try:
+        dpi = int(dpi_raw) if dpi_raw is not None else None
+    except (TypeError, ValueError):
+        dpi = None
+
+    rotate = data.get("rotate")
+    try:
+        rotate_i = int(rotate) if rotate is not None else None
+    except (TypeError, ValueError):
+        rotate_i = None
+
+    width_px = _mm_to_px(width_mm, dpi)
+    height_px = _mm_to_px(height_mm, dpi)
+    # Catalogue canvas may be rotated vs the print bitmap (e.g. 30×50 @ 270 → 400×240).
+    if rotate_i in (90, 270) and width_px is not None and height_px is not None:
+        print_width_px, print_height_px = height_px, width_px
+    else:
+        print_width_px, print_height_px = width_px, height_px
+
+    label_names: dict[str, str] = {}
+    for entry in list(data.get("names") or []) + list(data.get("labelNames") or []):
+        code = entry.get("languageCode")
+        name = entry.get("name")
+        if code and name:
+            label_names[code] = name
+
+    margin = data.get("margin")
+    if margin is not None and not isinstance(margin, list):
+        margin = None
+
+    return LabelInfo(
+        label_name=_pick_name(data),
+        catalog_barcode=data.get("barcode"),
+        label_width_mm=width_mm,
+        label_height_mm=height_mm,
+        label_width_px=width_px,
+        label_height_px=height_px,
+        print_width_px=print_width_px,
+        print_height_px=print_height_px,
+        dpi=dpi,
+        paper_type=data.get("paperType"),
+        consumable_type=data.get("consumableType"),
+        rotate=rotate_i,
+        canvas_rotate=data.get("canvasRotate"),
+        margin=margin,
+        preview_url=data.get("previewImage"),
+        thumbnail_url=data.get("thumbnail"),
+        background_image_url=data.get("backgroundImage"),
+        content_thumbnail_url=data.get("contentThumbnail"),
+        template_id=data.get("id"),
+        origin_template_id=data.get("originTemplateId"),
+        version=data.get("version"),
+        commodity_template=data.get("commodityTemplate"),
+        is_cable=data.get("isCable"),
+        cable_direction=data.get("cableDirection"),
+        cable_length=data.get("cableLength"),
+        marketing_category_id=data.get("marketingCategoryId"),
+        sticky=data.get("sticky"),
+        has_vip_res=data.get("hasVipRes"),
+        label_names=label_names or None,
+    )
 
 
 def _format_error(err: BaseException) -> str:
@@ -92,13 +175,7 @@ def _format_error(err: BaseException) -> str:
 
 
 class LabelCloudLookup:
-    """Resolves a label barcode to name/size/preview via the NIIMBOT cloud catalogue.
-
-    Matches and definitive "not found" (HTTP 200, no data) are cached to disk.
-    Transient failures (timeout, non-200, malformed body) are not cached so the
-    next poll can retry. Callers should check ``last_result_definitive`` when
-    ``get`` returns None to decide whether to suppress further lookups.
-    """
+    """Resolves a label barcode to name/size/preview via the NIIMBOT cloud catalogue."""
 
     def __init__(self, hass: HomeAssistant) -> None:
         self._hass = hass
@@ -187,7 +264,6 @@ class LabelCloudLookup:
             )
             return None, False
         except (aiohttp.ClientError, OSError) as err:
-            # OSError covers SSLError; str(SSLError) is often empty.
             self.last_error = _format_error(err)
             _LOGGER.warning(
                 "Cloud label lookup for %s failed: %s",
@@ -216,12 +292,4 @@ class LabelCloudLookup:
             _LOGGER.debug("Cloud label lookup for %s: no match", barcode)
             return None, True
 
-        return (
-            LabelInfo(
-                label_name=_pick_name(data),
-                label_width_mm=data.get("width"),
-                label_height_mm=data.get("height"),
-                preview_url=data.get("previewImage"),
-            ),
-            True,
-        )
+        return parse_label_data(data), True

--- a/custom_components/niimbot/render.py
+++ b/custom_components/niimbot/render.py
@@ -42,17 +42,40 @@ def _make_context(hass, *, default_font, palette):
     )
 
 
-def render_image(entity_id, service, hass):
+def render_image(entity_id, service, hass, defaults: dict | None = None):
+    """Render a label image from the print service payload.
+
+    ``defaults`` supplies width/height/rotate when the service call omits them
+    (typically from a successful cloud label lookup).
+    """
+    defaults = defaults or {}
     try:
+        width = (
+            service.data["width"]
+            if "width" in service.data
+            else defaults.get("width", 400)
+        )
+        height = (
+            service.data["height"]
+            if "height" in service.data
+            else defaults.get("height", 240)
+        )
+        rotate = (
+            service.data["rotate"]
+            if "rotate" in service.data
+            else defaults.get("rotate", 0)
+        )
         return render(
             payload=service.data.get("payload", ""),
-            width=service.data.get("width", 400),
-            height=service.data.get("height", 240),
-            rotate=service.data.get("rotate", 0),
-            rotate_mode="image",    # label printer: variable size, drawing rotates
+            width=width,
+            height=height,
+            rotate=rotate,
+            rotate_mode="image",  # label printer: variable size, drawing rotates
             background=service.data.get("background", "white"),
             dither=False,
-            context=_make_context(hass, default_font="ppb.ttf", palette=["black", "white"]),
+            context=_make_context(
+                hass, default_font="ppb.ttf", palette=["black", "white"]
+            ),
         )
     except RenderError as err:
         raise HomeAssistantError(str(err)) from err

--- a/custom_components/niimbot/sensor.py
+++ b/custom_components/niimbot/sensor.py
@@ -523,18 +523,7 @@ class NiimbotCloudLabelInfoSensor(NiimbotSensor):
         state = self._device._cloud_lookup_state
         if not state:
             return None
-        attrs = {
-            "status": state.get("status"),
-            "barcode": state.get("barcode"),
-            "requested_at": state.get("requested_at"),
-            "source": state.get("source"),
-            "error": state.get("error"),
-            "label_name": state.get("label_name"),
-            "label_width_mm": state.get("label_width_mm"),
-            "label_height_mm": state.get("label_height_mm"),
-            "preview_url": state.get("preview_url"),
-        }
-        return {key: value for key, value in attrs.items() if value is not None}
+        return {key: value for key, value in state.items() if value is not None}
 
 
 class NiimbotRibbonRfidSensor(NiimbotSensor):

--- a/custom_components/niimbot/services.yaml
+++ b/custom_components/niimbot/services.yaml
@@ -30,7 +30,6 @@ print:
     width:
       required: false
       example: 400
-      default: 400
       selector:
         number:
           min: 10
@@ -39,7 +38,6 @@ print:
     height:
       required: false
       example: 240
-      default: 240
       selector:
         number:
           min: 10

--- a/custom_components/niimbot/strings.json
+++ b/custom_components/niimbot/strings.json
@@ -69,11 +69,11 @@
         },
         "width": {
           "name": "Width",
-          "description": "Width of the label."
+          "description": "Label width in pixels. When omitted and Fetch Label Info Online has resolved the loaded roll, uses the catalogue print size."
         },
         "height": {
           "name": "Height",
-          "description": "Height of the label."
+          "description": "Label height in pixels. When omitted and Fetch Label Info Online has resolved the loaded roll, uses the catalogue print size."
         },
         "density": {
           "name": "Density",
@@ -81,7 +81,7 @@
         },
         "label_type": {
           "name": "Label Type",
-          "description": "Label type code (1=Gap, 2=Black, 3=Continuous, 4=Perforated, 5=Transparent, 6=PvcTag, 10=BlackMarkGap, 11=HeatShrinkTube). Default: model's primary paper type."
+          "description": "Label type code (1=Gap, 2=Black, 3=Continuous, 4=Perforated, 5=Transparent, 6=PvcTag, 10=BlackMarkGap, 11=HeatShrinkTube). When omitted, uses the online catalogue paper type if available, otherwise the model's primary paper type."
         },
         "copies": {
           "name": "Copies",

--- a/custom_components/niimbot/translations/en.json
+++ b/custom_components/niimbot/translations/en.json
@@ -61,11 +61,11 @@
                 },
                 "width": {
                     "name": "Width",
-                    "description": "Width of the label."
+                    "description": "Label width in pixels. When omitted and Fetch Label Info Online has resolved the loaded roll, uses the catalogue print size."
                 },
                 "height": {
                     "name": "Height",
-                    "description": "Height of the label."
+                    "description": "Label height in pixels. When omitted and Fetch Label Info Online has resolved the loaded roll, uses the catalogue print size."
                 },
                 "density": {
                     "name": "Density",
@@ -73,7 +73,7 @@
                 },
                 "label_type": {
                     "name": "Label Type",
-                    "description": "Label type code (1=Gap, 2=Black, 3=Continuous, 4=Perforated, 5=Transparent, 6=PvcTag, 10=BlackMarkGap, 11=HeatShrinkTube). Default: model's primary paper type."
+                    "description": "Label type code (1=Gap, 2=Black, 3=Continuous, 4=Perforated, 5=Transparent, 6=PvcTag, 10=BlackMarkGap, 11=HeatShrinkTube). When omitted, uses the online catalogue paper type if available, otherwise the model's primary paper type."
                 },
                 "copies": {
                     "name": "Copies",

--- a/custom_components/niimbot/translations/ko.json
+++ b/custom_components/niimbot/translations/ko.json
@@ -61,11 +61,11 @@
                 },
                 "width": {
                     "name": "너비",
-                    "description": "라벨 너비입니다."
+                    "description": "라벨 너비(픽셀). 생략 시 온라인 라벨 정보가 있으면 카탈로그 인쇄 크기를 사용합니다."
                 },
                 "height": {
                     "name": "높이",
-                    "description": "라벨 높이입니다."
+                    "description": "라벨 높이(픽셀). 생략 시 온라인 라벨 정보가 있으면 카탈로그 인쇄 크기를 사용합니다."
                 },
                 "density": {
                     "name": "농도",
@@ -73,7 +73,7 @@
                 },
                 "label_type": {
                     "name": "라벨 타입",
-                    "description": "라벨 타입 코드 (1=Gap, 2=Black, 3=Continuous, 4=Perforated, 5=Transparent, 6=PvcTag, 10=BlackMarkGap, 11=HeatShrinkTube). 기본값: 프린터 모델의 기본 라벨 타입."
+                    "description": "라벨 타입 코드 (1=Gap, 2=Black, 3=Continuous, 4=Perforated, 5=Transparent, 6=PvcTag, 10=BlackMarkGap, 11=HeatShrinkTube). 생략 시 온라인 카탈로그 용지 타입이 있으면 그것을, 없으면 모델 기본 타입을 사용합니다."
                 },
                 "copies": {
                     "name": "매수",

--- a/tests/test_cloud_lookup.py
+++ b/tests/test_cloud_lookup.py
@@ -10,7 +10,11 @@ import asyncio
 
 import aiohttp
 
-from custom_components.niimbot.cloud import LabelCloudLookup, _pick_name
+from custom_components.niimbot.cloud import (
+    LabelCloudLookup,
+    _pick_name,
+    parse_label_data,
+)
 
 
 def run(coro):
@@ -96,7 +100,38 @@ SUCCESS_BODY = {
         ],
         "width": 50,
         "height": 30,
+        "paccuracyName": 203,
+        "paperType": 1,
+        "rotate": 0,
         "previewImage": "https://oss-print.niimbot.com/preview.png",
+        "barcode": "6972842748577",
+    },
+    "code": 1,
+}
+
+# Real B1 SKU shape: empty names[], sizes in labelNames, canvas rotated 270°.
+B1_SKU_BODY = {
+    "data": {
+        "id": 154629949,
+        "names": [],
+        "labelNames": [
+            {"languageCode": "zh-cn", "name": "T50*30-230白色"},
+            {"languageCode": "en", "name": "T50*30-230WHITE-NM"},
+            {"languageCode": "ko", "name": "T50*30-230WHITE"},
+        ],
+        "width": 30,
+        "height": 50,
+        "paccuracyName": 203,
+        "paperType": 1,
+        "consumableType": 1,
+        "rotate": 270,
+        "canvasRotate": 90,
+        "margin": [0, 0, 0, 0],
+        "previewImage": "https://oss-print.niimbot.com/preview.png",
+        "thumbnail": "https://oss-print.niimbot.com/thumb.png",
+        "backgroundImage": "https://oss-print.niimbot.com/bg.png",
+        "barcode": "6971501227941",
+        "version": "3.0.0",
     },
     "code": 1,
 }
@@ -128,6 +163,36 @@ def test_pick_name_handles_no_names_at_all():
     assert _pick_name({}) is None
 
 
+def test_pick_name_uses_label_names_when_names_empty():
+    assert _pick_name(B1_SKU_BODY["data"]) == "T50*30-230WHITE-NM"
+
+
+def test_parse_label_data_computes_pixels_and_print_size():
+    info = parse_label_data(SUCCESS_BODY["data"])
+    assert info["label_width_mm"] == 50
+    assert info["label_height_mm"] == 30
+    assert info["dpi"] == 203
+    assert info["label_width_px"] == 400
+    assert info["label_height_px"] == 240
+    assert info["print_width_px"] == 400
+    assert info["print_height_px"] == 240
+    assert info["paper_type"] == 1
+
+
+def test_parse_label_data_swaps_print_size_when_rotated():
+    info = parse_label_data(B1_SKU_BODY["data"])
+    assert info["label_name"] == "T50*30-230WHITE-NM"
+    assert info["label_width_mm"] == 30
+    assert info["label_height_mm"] == 50
+    assert info["label_width_px"] == 240
+    assert info["label_height_px"] == 400
+    # rotate 270 → print bitmap is swapped vs catalogue canvas
+    assert info["print_width_px"] == 400
+    assert info["print_height_px"] == 240
+    assert info["catalog_barcode"] == "6971501227941"
+    assert info["label_names"]["ko"] == "T50*30-230WHITE"
+
+
 def test_get_returns_none_for_empty_barcode():
     async def _test():
         lookup = LabelCloudLookup(hass=object())
@@ -148,12 +213,15 @@ def test_get_fetches_and_caches_on_success(monkeypatch):
         lookup = _lookup_with(monkeypatch, session, store)
 
         info = await lookup.get("6972842748577")
-        assert info == {
-            "label_name": "White 50x30",
-            "label_width_mm": 50,
-            "label_height_mm": 30,
-            "preview_url": "https://oss-print.niimbot.com/preview.png",
-        }
+        assert info["label_name"] == "White 50x30"
+        assert info["label_width_mm"] == 50
+        assert info["label_height_mm"] == 30
+        assert info["label_width_px"] == 400
+        assert info["label_height_px"] == 240
+        assert info["print_width_px"] == 400
+        assert info["print_height_px"] == 240
+        assert info["preview_url"] == "https://oss-print.niimbot.com/preview.png"
+        assert info["dpi"] == 203
         assert session.calls == ["6972842748577"]
         assert lookup.last_source == "network"
 


### PR DESCRIPTION
## Summary
- Expose parseable catalogue fields on Cloud Label Info (mm + px, DPI, paper type, label names, assets, template ids, …)
- Derive \`print_width_px\` / \`print_height_px\` from mm@DPI with 90/270 rotate swap (e.g. 30×50 @270 → 400×240)
- \`niimbot.print\` uses those sizes and \`paper_type\` when width/height/label_type are omitted
- Prefer \`labelNames\` when \`names\` is empty (fixes empty name for SKU 10262260)

## Test plan
- [ ] Reload; Cloud Label Info shows name, mm, px, print_*_px, paper_type, label_names
- [ ] Print with only payload (no width/height) renders at catalogue print size
- [ ] Explicit width/height still override cloud defaults


Made with [Cursor](https://cursor.com)