### PR TITLE
Remove Cancel Print button

### DIFF
--- a/custom_components/niimbot/button.py
+++ b/custom_components/niimbot/button.py
@@ -36,7 +36,6 @@ async def async_setup_entry(
     device: NiimbotDevice = hass.data[DOMAIN][entry.entry_id]["device"]
 
     entities: list[ButtonEntity] = [
-        NiimbotCancelPrintButton(coordinator, coordinator.data, device),
         NiimbotPrinterResetButton(coordinator, coordinator.data, device),
     ]
 
@@ -153,31 +152,6 @@ class NiimbotCalibrateHeightButton(NiimbotBaseButton):
                 raise HomeAssistantError("Printer rejected roll feed calibration")
         except Exception as err:
             _reraise_action_error("calibrate roll feed", err)
-
-
-class NiimbotCancelPrintButton(NiimbotBaseButton):
-    """Button to cancel an in-flight print job."""
-
-    def __init__(
-        self,
-        coordinator: DataUpdateCoordinator[BLEData],
-        ble_data: BLEData,
-        device: NiimbotDevice,
-    ) -> None:
-        super().__init__(coordinator, ble_data, device, "cancel_print")
-
-    @property
-    def available(self) -> bool:
-        return super().available and self._device.is_printing
-
-    async def async_press(self) -> None:
-        ble_dev = self._get_ble_device()
-        try:
-            ok = await self._device.cancel_print(ble_dev)
-            if not ok:
-                raise HomeAssistantError("Printer rejected cancel print request")
-        except Exception as err:
-            _reraise_action_error("cancel print", err)
 
 
 class NiimbotPrinterResetButton(NiimbotBaseButton):

--- a/custom_components/niimbot/icons.json
+++ b/custom_components/niimbot/icons.json
@@ -12,9 +12,6 @@
             "calibrate_roll_feed": {
                 "default": "mdi:ruler"
             },
-            "cancel_print": {
-                "default": "mdi:cancel"
-            },
             "reset_printer_settings": {
                 "default": "mdi:restart"
             },

--- a/custom_components/niimbot/strings.json
+++ b/custom_components/niimbot/strings.json
@@ -262,9 +262,6 @@
       "calibrate_roll_feed": {
         "name": "Calibrate Roll Feed"
       },
-      "cancel_print": {
-        "name": "Cancel Print"
-      },
       "reset_printer_settings": {
         "name": "Reset Printer Settings"
       },

--- a/custom_components/niimbot/translations/en.json
+++ b/custom_components/niimbot/translations/en.json
@@ -254,9 +254,6 @@
             "calibrate_roll_feed": {
                 "name": "Calibrate Roll Feed"
             },
-            "cancel_print": {
-                "name": "Cancel Print"
-            },
             "reset_printer_settings": {
                 "name": "Reset Printer Settings"
             },

--- a/custom_components/niimbot/translations/ko.json
+++ b/custom_components/niimbot/translations/ko.json
@@ -254,9 +254,6 @@
             "calibrate_roll_feed": {
                 "name": "롤 피드 보정"
             },
-            "cancel_print": {
-                "name": "인쇄 취소"
-            },
             "reset_printer_settings": {
                 "name": "프린터 설정 초기화"
             },

--- a/tests/test_platform_imports.py
+++ b/tests/test_platform_imports.py
@@ -25,7 +25,6 @@ def test_platform_module_imports(module_name: str) -> None:
 def test_button_module_defines_action_entities() -> None:
     button = importlib.import_module("custom_components.niimbot.button")
     for name in (
-        "NiimbotCancelPrintButton",
         "NiimbotPrinterResetButton",
         "NiimbotCalibrateHeightButton",
         "NiimbotCalibrateLabelPositionButton",


### PR DESCRIPTION
## Summary
- Remove the Cancel Print button entity, translations, and icon
- Keep \`0xDA\` CancelPrint for in-flight print-loop cancellation

## Test plan
- [ ] After reload, Cancel Print entity is gone (delete leftover restored entity if shown)
- [ ] Printing still works


Made with [Cursor](https://cursor.com)