### PR TITLE
Fix BLE discovery matching and filter manual setup by service UUID (#102)

### DIFF
--- a/custom_components/niimbot/config_flow.py
+++ b/custom_components/niimbot/config_flow.py
@@ -93,44 +93,15 @@ class Discovery:
 
 NIIMBOT_NAME_PREFIXES = (
     "A63",
-    "B1",
-    "B2",
-    "B3",
-    "B4",
-    "B11",
-    "B16",
+    "B1-",
+    "B1_",
     "B18",
-    "B203",
+    "B2-",
+    "B2_",
     "B21",
-    "B31",
-    "B32",
-    "B50",
+    "B3S",
     "D11",
-    "D101",
-    "D41",
-    "D61",
-    "DXX",
     "T2S",
-    "T6",
-    "T7",
-    "T8",
-    "H1",
-    "JC",
-    "K2",
-    "K3",
-    "K4",
-    "M2",
-    "M3",
-    "P1",
-    "P18",
-    "S1",
-    "S3",
-    "S6",
-    "A8",
-    "A20",
-    "A203",
-    "C1",
-    "ET10",
     "NIIMBOT",
 )
 
@@ -219,13 +190,11 @@ class NiimbotConfigFlow(ConfigFlow, domain=DOMAIN):
             if address in current_addresses or address in self._discovered_devices:
                 continue
 
-            is_nameless = not discovery_info.name or discovery_info.name == address
-            is_niimbot = (
-                is_nameless
+            matched = (
+                NIIMBOT_SERVICE_UUID in discovery_info.service_uuids
                 or _name_looks_like_niimbot(discovery_info.name, address)
-                or NIIMBOT_SERVICE_UUID in discovery_info.service_uuids
             )
-            if is_niimbot:
+            if matched:
                 name = _discovery_display_name(discovery_info)
                 self._discovered_devices[address] = Discovery(name, discovery_info)
 

--- a/custom_components/niimbot/config_flow.py
+++ b/custom_components/niimbot/config_flow.py
@@ -135,9 +135,9 @@ NIIMBOT_NAME_PREFIXES = (
 )
 
 
-def _name_looks_like_niimbot(name: str | None) -> bool:
+def _name_looks_like_niimbot(name: str | None, address: str | None = None) -> bool:
     """Check if the device name begins with a known Niimbot model prefix."""
-    if not name:
+    if not name or (address and name == address):
         return False
     upper = name.upper()
     return any(upper.startswith(prefix) for prefix in NIIMBOT_NAME_PREFIXES)
@@ -214,30 +214,18 @@ class NiimbotConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(title=discovery.name, data=user_input)
 
         current_addresses = self._async_current_ids()
-        all_discovered = list(async_discovered_service_info(self.hass))
-
-        # First pass: look for devices matching Niimbot service UUID or known name prefixes
-        for discovery_info in all_discovered:
+        for discovery_info in async_discovered_service_info(self.hass):
             address = discovery_info.address
             if address in current_addresses or address in self._discovered_devices:
                 continue
 
-            matched = (
-                NIIMBOT_SERVICE_UUID in discovery_info.service_uuids
-                or _name_looks_like_niimbot(discovery_info.name)
+            is_nameless = not discovery_info.name or discovery_info.name == address
+            is_niimbot = (
+                is_nameless
+                or _name_looks_like_niimbot(discovery_info.name, address)
+                or NIIMBOT_SERVICE_UUID in discovery_info.service_uuids
             )
-            if matched:
-                _LOGGER.debug("Found Niimbot candidate: %s (%s)", discovery_info.name, address)
-                name = _discovery_display_name(discovery_info)
-                self._discovered_devices[address] = Discovery(name, discovery_info)
-
-        # Fallback: if no devices matched the Niimbot filters, list all available
-        # unconfigured BLE devices so the user can select their printer by MAC address.
-        if not self._discovered_devices:
-            for discovery_info in all_discovered:
-                address = discovery_info.address
-                if address in current_addresses or address in self._discovered_devices:
-                    continue
+            if is_niimbot:
                 name = _discovery_display_name(discovery_info)
                 self._discovered_devices[address] = Discovery(name, discovery_info)
 

--- a/custom_components/niimbot/config_flow.py
+++ b/custom_components/niimbot/config_flow.py
@@ -35,6 +35,7 @@ from .const import (
     DEFAULT_KEEP_CONNECTION,
     DEFAULT_USE_CLOUD_LABEL_INFO,
     DOMAIN,
+    NIIMBOT_SERVICE_UUID,
 )
 
 
@@ -101,6 +102,7 @@ class NiimbotConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize the config flow."""
+        super().__init__()
         self._discovered_device: Discovery | None = None
         self._discovered_devices: dict[str, Discovery] = {}
 
@@ -112,7 +114,11 @@ class NiimbotConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(discovery_info.address)
         self._abort_if_unique_id_configured()
 
-        name = discovery_info.advertisement.local_name
+        name = (
+            discovery_info.advertisement.local_name
+            or discovery_info.device.name
+            or f"Niimbot ({discovery_info.address})"
+        )
         self.context["title_placeholders"] = {"name": name}
         self._discovered_device = Discovery(name, discovery_info)
 
@@ -157,35 +163,17 @@ class NiimbotConfigFlow(ConfigFlow, domain=DOMAIN):
             if address in current_addresses or address in self._discovered_devices:
                 continue
 
-            ##
-
-            if discovery_info.advertisement.local_name is None:
+            if NIIMBOT_SERVICE_UUID not in discovery_info.service_uuids:
                 continue
-            # if not (
-            #     discovery_info.advertisement.local_name.startswith("FR:RU")
-            #     or discovery_info.advertisement.local_name.startswith("FR:RE")
-            #     or discovery_info.advertisement.local_name.startswith("FR:GI")
-            #     or discovery_info.advertisement.local_name.startswith("FR:H")
-            #     or discovery_info.advertisement.local_name.startswith("FR:R2")
-            #     or discovery_info.advertisement.local_name.startswith("FR:RD")
-            #     or discovery_info.advertisement.local_name.startswith("FR:GL")
-            #     or discovery_info.advertisement.local_name.startswith("FR:GJ")
-            #     or discovery_info.advertisement.local_name.startswith("FR:I")
-            # ):
-            #     continue
 
-            _LOGGER.debug("Found My Device")
-            _LOGGER.debug("Niimbot0 Discovery address: %s", address)
-            _LOGGER.debug("Niimbot0 Man Data: %s", discovery_info.manufacturer_data)
-            _LOGGER.debug("Niimbot0 advertisement: %s", discovery_info.advertisement)
-            _LOGGER.debug("Niimbot0 device: %s", discovery_info.device)
-            _LOGGER.debug("Niimbot0 service data: %s", discovery_info.service_data)
-            _LOGGER.debug("Niimbot0 service uuids: %s", discovery_info.service_uuids)
-            _LOGGER.debug("Niimbot0 rssi: %s", discovery_info.rssi)
-            _LOGGER.debug(
-                "Niimbot0 advertisement: %s", discovery_info.advertisement.local_name
+            _LOGGER.debug("Found Niimbot device via service UUID: %s", address)
+            _LOGGER.debug("Niimbot discovery info: %s", discovery_info)
+
+            name = (
+                discovery_info.advertisement.local_name
+                or discovery_info.device.name
+                or f"Niimbot ({address})"
             )
-            name = discovery_info.advertisement.local_name
             self._discovered_devices[address] = Discovery(name, discovery_info)
 
         if not self._discovered_devices:

--- a/custom_components/niimbot/config_flow.py
+++ b/custom_components/niimbot/config_flow.py
@@ -91,6 +91,66 @@ class Discovery:
     discovery_info: BluetoothServiceInfo
 
 
+NIIMBOT_NAME_PREFIXES = (
+    "A63",
+    "B1",
+    "B2",
+    "B3",
+    "B4",
+    "B11",
+    "B16",
+    "B18",
+    "B203",
+    "B21",
+    "B31",
+    "B32",
+    "B50",
+    "D11",
+    "D101",
+    "D41",
+    "D61",
+    "DXX",
+    "T2S",
+    "T6",
+    "T7",
+    "T8",
+    "H1",
+    "JC",
+    "K2",
+    "K3",
+    "K4",
+    "M2",
+    "M3",
+    "P1",
+    "P18",
+    "S1",
+    "S3",
+    "S6",
+    "A8",
+    "A20",
+    "A203",
+    "C1",
+    "ET10",
+    "NIIMBOT",
+)
+
+
+def _name_looks_like_niimbot(name: str | None) -> bool:
+    """Check if the device name begins with a known Niimbot model prefix."""
+    if not name:
+        return False
+    upper = name.upper()
+    return any(upper.startswith(prefix) for prefix in NIIMBOT_NAME_PREFIXES)
+
+
+def _discovery_display_name(discovery_info: BluetoothServiceInfo) -> str:
+    """Return a user-friendly display name for a discovered Bluetooth device."""
+    name = discovery_info.name
+    if not name or name == discovery_info.address:
+        return f"Niimbot ({discovery_info.address})"
+    return name
+
+
 class NiimbotDeviceUpdateError(Exception):
     """Custom error class for device updates."""
 
@@ -114,11 +174,7 @@ class NiimbotConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(discovery_info.address)
         self._abort_if_unique_id_configured()
 
-        name = (
-            discovery_info.advertisement.local_name
-            or discovery_info.device.name
-            or f"Niimbot ({discovery_info.address})"
-        )
+        name = _discovery_display_name(discovery_info)
         self.context["title_placeholders"] = {"name": name}
         self._discovered_device = Discovery(name, discovery_info)
 
@@ -158,23 +214,32 @@ class NiimbotConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_create_entry(title=discovery.name, data=user_input)
 
         current_addresses = self._async_current_ids()
-        for discovery_info in async_discovered_service_info(self.hass):
+        all_discovered = list(async_discovered_service_info(self.hass))
+
+        # First pass: look for devices matching Niimbot service UUID or known name prefixes
+        for discovery_info in all_discovered:
             address = discovery_info.address
             if address in current_addresses or address in self._discovered_devices:
                 continue
 
-            if NIIMBOT_SERVICE_UUID not in discovery_info.service_uuids:
-                continue
-
-            _LOGGER.debug("Found Niimbot device via service UUID: %s", address)
-            _LOGGER.debug("Niimbot discovery info: %s", discovery_info)
-
-            name = (
-                discovery_info.advertisement.local_name
-                or discovery_info.device.name
-                or f"Niimbot ({address})"
+            matched = (
+                NIIMBOT_SERVICE_UUID in discovery_info.service_uuids
+                or _name_looks_like_niimbot(discovery_info.name)
             )
-            self._discovered_devices[address] = Discovery(name, discovery_info)
+            if matched:
+                _LOGGER.debug("Found Niimbot candidate: %s (%s)", discovery_info.name, address)
+                name = _discovery_display_name(discovery_info)
+                self._discovered_devices[address] = Discovery(name, discovery_info)
+
+        # Fallback: if no devices matched the Niimbot filters, list all available
+        # unconfigured BLE devices so the user can select their printer by MAC address.
+        if not self._discovered_devices:
+            for discovery_info in all_discovered:
+                address = discovery_info.address
+                if address in current_addresses or address in self._discovered_devices:
+                    continue
+                name = _discovery_display_name(discovery_info)
+                self._discovered_devices[address] = Discovery(name, discovery_info)
 
         if not self._discovered_devices:
             return self.async_abort(reason="no_devices_found")

--- a/custom_components/niimbot/const.py
+++ b/custom_components/niimbot/const.py
@@ -4,8 +4,9 @@ import base64
 from .niimprint import BLEData
 from homeassistant.components.image import Image
 
+from .niimprint.printer import SERVICE_UUID as NIIMBOT_SERVICE_UUID
+
 DOMAIN = "niimbot"
-NIIMBOT_SERVICE_UUID = "e7810a71-73ae-499d-8c15-faa9aef0c3f2"
 CONF_USE_SOUND = "use_sound"
 CONF_WAIT_BETWEEN_EACH_PRINT_LINE = "wait_between_each_print_line"
 CONF_CONFIRM_EVERY_NTH_PRINT_LINE = "confirm_every_nth_print_line"

--- a/custom_components/niimbot/const.py
+++ b/custom_components/niimbot/const.py
@@ -5,6 +5,7 @@ from .niimprint import BLEData
 from homeassistant.components.image import Image
 
 DOMAIN = "niimbot"
+NIIMBOT_SERVICE_UUID = "e7810a71-73ae-499d-8c15-faa9aef0c3f2"
 CONF_USE_SOUND = "use_sound"
 CONF_WAIT_BETWEEN_EACH_PRINT_LINE = "wait_between_each_print_line"
 CONF_CONFIRM_EVERY_NTH_PRINT_LINE = "confirm_every_nth_print_line"

--- a/custom_components/niimbot/manifest.json
+++ b/custom_components/niimbot/manifest.json
@@ -4,13 +4,19 @@
       "local_name": "A63*"
     },
     {
-      "local_name": "B1*"
+      "local_name": "B1-*"
+    },
+    {
+      "local_name": "B1_*"
     },
     {
       "local_name": "B18*"
     },
     {
-      "local_name": "B2*"
+      "local_name": "B2-*"
+    },
+    {
+      "local_name": "B2_*"
     },
     {
       "local_name": "B21*"
@@ -22,10 +28,10 @@
       "local_name": "D11*"
     },
     {
-      "local_name": "D110*"
+      "local_name": "T2S*"
     },
     {
-      "local_name": "T2S*"
+      "service_uuid": "e7810a71-73ae-499d-8c15-faa9aef0c3f2"
     }
   ],
   "codeowners": [

--- a/custom_components/niimbot/manifest.json
+++ b/custom_components/niimbot/manifest.json
@@ -1,37 +1,31 @@
 {
   "bluetooth": [
     {
-      "local_name": "A63-*"
+      "local_name": "A63*"
     },
     {
-      "local_name": "B1-*"
+      "local_name": "B1*"
     },
     {
-      "local_name": "B18-*"
+      "local_name": "B18*"
     },
     {
-      "local_name": "B2-*"
+      "local_name": "B2*"
     },
     {
-      "local_name": "B2_Pro-*"
+      "local_name": "B21*"
     },
     {
-      "local_name": "B2_PRO-*"
+      "local_name": "B3S*"
     },
     {
-      "local_name": "B21-*"
+      "local_name": "D11*"
     },
     {
-      "local_name": "B3S-*"
+      "local_name": "D110*"
     },
     {
-      "local_name": "D11-*"
-    },
-    {
-      "local_name": "D110-*"
-    },
-    {
-      "local_name": "T2S-*"
+      "local_name": "T2S*"
     }
   ],
   "codeowners": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,27 @@ from unittest.mock import MagicMock
 # Base class mock supporting subclassing and subscripting (e.g. BaseClass[T])
 class MockBase:
     def __init__(self, *args, **kwargs):
+        self.context = {}
+
+    def _async_current_ids(self):
+        return set()
+
+    def async_show_form(self, **kwargs):
+        return {"type": "form", **kwargs}
+
+    def async_abort(self, **kwargs):
+        return {"type": "abort", **kwargs}
+
+    def async_create_entry(self, **kwargs):
+        return {"type": "create_entry", **kwargs}
+
+    async def async_set_unique_id(self, *args, **kwargs):
+        pass
+
+    def _abort_if_unique_id_configured(self):
+        pass
+
+    def __init_subclass__(cls, **kwargs):
         pass
 
     def __class_getitem__(cls, item):
@@ -63,10 +84,21 @@ ha_bt_processor.PassiveBluetoothProcessorCoordinator = MockBase
 ha_bt_processor.PassiveBluetoothDataProcessor = MockBase
 sys.modules["homeassistant.components.bluetooth.passive_update_processor"] = ha_bt_processor
 
-sys.modules["homeassistant.config_entries"] = MagicMock()
-sys.modules["homeassistant.const"] = MagicMock()
+ha_config_entries = MagicMock()
+ha_config_entries.ConfigFlow = MockBase
+ha_config_entries.OptionsFlowWithReload = MockBase
+sys.modules["homeassistant.config_entries"] = ha_config_entries
+
+sys.modules["homeassistant.data_entry_flow"] = MagicMock()
+
+ha_const = MagicMock()
+ha_const.CONF_ADDRESS = "address"
+ha_const.CONF_SCAN_INTERVAL = "scan_interval"
+sys.modules["homeassistant.const"] = ha_const
+
 sys.modules["homeassistant.core"] = MagicMock()
 sys.modules["homeassistant.helpers"] = MagicMock()
+sys.modules["homeassistant.helpers.selector"] = MagicMock()
 sys.modules["homeassistant.helpers.device_registry"] = MagicMock()
 sys.modules["homeassistant.helpers.entity"] = MagicMock()
 sys.modules["homeassistant.helpers.entity_platform"] = MagicMock()
@@ -161,3 +193,14 @@ try:
     import imagespec  # noqa: F401
 except ImportError:
     sys.modules["imagespec"] = MagicMock()
+
+try:
+    import voluptuous  # noqa: F401
+except ImportError:
+    vol_mock = MagicMock()
+    vol_mock.Required = lambda key, default=None: key
+    vol_mock.Optional = lambda key, default=None: key
+    vol_mock.In = lambda values: values
+    vol_mock.Schema = lambda schema: schema
+    sys.modules["voluptuous"] = vol_mock
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,18 @@ from unittest.mock import MagicMock
 # Base class mock supporting subclassing and subscripting (e.g. BaseClass[T])
 class MockBase:
     def __init__(self, *args, **kwargs):
+        pass
+
+    def __init_subclass__(cls, **kwargs):
+        pass
+
+    def __class_getitem__(cls, item):
+        return cls
+
+
+class MockConfigFlow(MockBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.context = {}
 
     def _async_current_ids(self):
@@ -25,12 +37,6 @@ class MockBase:
 
     def _abort_if_unique_id_configured(self):
         pass
-
-    def __init_subclass__(cls, **kwargs):
-        pass
-
-    def __class_getitem__(cls, item):
-        return cls
 
 
 def _make_entity_base(name: str):
@@ -85,8 +91,8 @@ ha_bt_processor.PassiveBluetoothDataProcessor = MockBase
 sys.modules["homeassistant.components.bluetooth.passive_update_processor"] = ha_bt_processor
 
 ha_config_entries = MagicMock()
-ha_config_entries.ConfigFlow = MockBase
-ha_config_entries.OptionsFlowWithReload = MockBase
+ha_config_entries.ConfigFlow = MockConfigFlow
+ha_config_entries.OptionsFlowWithReload = MockConfigFlow
 sys.modules["homeassistant.config_entries"] = ha_config_entries
 
 sys.modules["homeassistant.data_entry_flow"] = MagicMock()
@@ -203,4 +209,3 @@ except ImportError:
     vol_mock.In = lambda values: values
     vol_mock.Schema = lambda schema: schema
     sys.modules["voluptuous"] = vol_mock
-

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,7 +6,11 @@ import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.const import CONF_ADDRESS, CONF_SCAN_INTERVAL
-from custom_components.niimbot.config_flow import NiimbotConfigFlow, Discovery
+from custom_components.niimbot.config_flow import (
+    NiimbotConfigFlow,
+    Discovery,
+    NIIMBOT_NAME_PREFIXES,
+)
 from custom_components.niimbot.const import (
     CONF_CONFIRM_EVERY_NTH_PRINT_LINE,
     CONF_KEEP_CONNECTION,
@@ -58,6 +62,21 @@ def test_manifest_local_name_matchers_have_no_wildcard_in_first_3_chars():
             assert "*" not in prefix and "[" not in prefix, (
                 f"Invalid matcher '{local_name}': first 3 chars '{prefix}' cannot contain wildcards"
             )
+
+
+def test_name_prefixes_stay_in_sync_with_manifest():
+    """manifest.json의 local_name 매처가 전부 config_flow 프리픽스에 반영돼 있어야 한다."""
+    with open(MANIFEST_PATH, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    manifest_prefixes = set()
+    for entry in manifest.get("bluetooth", []):
+        if local_name := entry.get("local_name"):
+            assert local_name.endswith("*"), f"예상치 못한 패턴 형태: {local_name}"
+            manifest_prefixes.add(local_name[:-1])
+
+    missing = manifest_prefixes - set(NIIMBOT_NAME_PREFIXES)
+    assert not missing, f"config_flow 프리픽스에 누락된 모델: {sorted(missing)}"
 
 
 def test_name_looks_like_niimbot_guards_mac_address_and_avoids_false_positives():

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -60,26 +60,41 @@ def test_manifest_local_name_matchers_have_no_wildcard_in_first_3_chars():
             )
 
 
-def test_name_looks_like_niimbot_guards_mac_address():
-    """Test that _name_looks_like_niimbot does not treat MAC addresses starting with B1/C1 as model names."""
+def test_name_looks_like_niimbot_guards_mac_address_and_avoids_false_positives():
+    """Test that _name_looks_like_niimbot matches true Niimbot devices and rejects false positives/MACs."""
     from custom_components.niimbot.config_flow import _name_looks_like_niimbot
 
-    # MAC address starting with B1 / C1 should NOT match model prefix
+    # MAC address starting with B1 / C1 / A8 should NOT match model prefix
     assert _name_looks_like_niimbot("B1:22:33:44:55:66", "B1:22:33:44:55:66") is False
     assert _name_looks_like_niimbot("C1:22:33:44:55:66", "C1:22:33:44:55:66") is False
+    assert _name_looks_like_niimbot("A8:3F:11:22:33:44", "A8:3F:11:22:33:44") is False
 
-    # Real model names should match
-    assert _name_looks_like_niimbot("B1-123456", "AA:BB:CC:DD:EE:01") is True
-    assert _name_looks_like_niimbot("D11_BF25_BLE", "AA:BB:CC:DD:EE:02") is True
-    assert _name_looks_like_niimbot("d11-test", "AA:BB:CC:DD:EE:03") is True
+    # Real model names (with hyphens or underscores) should match
+    assert _name_looks_like_niimbot("D11_BF25_BLE", "AA:BB:CC:DD:EE:01") is True
+    assert _name_looks_like_niimbot("D11-1234", "AA:BB:CC:DD:EE:02") is True
+    assert _name_looks_like_niimbot("B1-G723040259", "AA:BB:CC:DD:EE:03") is True
+    assert _name_looks_like_niimbot("B1_PRO", "AA:BB:CC:DD:EE:04") is True
+    assert _name_looks_like_niimbot("B2_Pro-9999", "AA:BB:CC:DD:EE:05") is True
+    assert _name_looks_like_niimbot("B2-0001", "AA:BB:CC:DD:EE:06") is True
+    assert _name_looks_like_niimbot("B18_0001", "AA:BB:CC:DD:EE:07") is True
+    assert _name_looks_like_niimbot("A63_0001", "AA:BB:CC:DD:EE:08") is True
+    assert _name_looks_like_niimbot("T2S_0001", "AA:BB:CC:DD:EE:09") is True
+    assert _name_looks_like_niimbot("B21-123456", "AA:BB:CC:DD:EE:10") is True
+    assert _name_looks_like_niimbot("B3S-1234", "AA:BB:CC:DD:EE:11") is True
+    assert _name_looks_like_niimbot("NIIMBOT-D11", "AA:BB:CC:DD:EE:12") is True
 
-    # Non-Niimbot device names should not match
-    assert _name_looks_like_niimbot("[TV] Samsung", "11:22:33:44:55:66") is False
-    assert _name_looks_like_niimbot("LYWSD03MMC", "22:33:44:55:66:77") is False
+    # False positives from generic non-Niimbot devices must be rejected
+    assert _name_looks_like_niimbot("S1 Earbuds", "11:22:33:44:55:66") is False
+    assert _name_looks_like_niimbot("P1 Mouse", "11:22:33:44:55:67") is False
+    assert _name_looks_like_niimbot("M2 Tracker", "11:22:33:44:55:68") is False
+    assert _name_looks_like_niimbot("C1 Sensor", "11:22:33:44:55:69") is False
+    assert _name_looks_like_niimbot("JCB-Terminal", "11:22:33:44:55:70") is False
+    assert _name_looks_like_niimbot("[TV] Samsung", "11:22:33:44:55:71") is False
+    assert _name_looks_like_niimbot("LYWSD03MMC", "11:22:33:44:55:72") is False
 
 
 def test_async_step_user_filters_by_service_uuid_and_name():
-    """Test that async_step_user includes Niimbot devices and nameless devices while filtering non-Niimbot named devices."""
+    """Test that async_step_user includes valid Niimbot devices and excludes non-Niimbot devices."""
     async def _test():
         flow = NiimbotConfigFlow()
         flow.hass = MagicMock()
@@ -87,25 +102,35 @@ def test_async_step_user_filters_by_service_uuid_and_name():
         d11_clone = _make_discovery_info(
             "AA:BB:CC:DD:EE:01",
             name="D11_BF25_BLE",
-            service_uuids=[NIIMBOT_SERVICE_UUID],
+            service_uuids=[],
         )
-        nameless_niimbot = _make_discovery_info(
+        b1_underscore = _make_discovery_info(
             "AA:BB:CC:DD:EE:02",
-            name=None,
-            service_uuids=[NIIMBOT_SERVICE_UUID],
+            name="B1_G723040259",
+            service_uuids=[],
         )
-        b21_printer_no_uuid = _make_discovery_info(
+        b21_printer = _make_discovery_info(
             "AA:BB:CC:DD:EE:03",
             name="B21-123456",
             service_uuids=[],
         )
-        nameless_raw_mac = _make_discovery_info(
+        uuid_matched_device = _make_discovery_info(
             "AA:BB:CC:DD:EE:04",
+            name=None,
+            service_uuids=[NIIMBOT_SERVICE_UUID],
+        )
+        random_nameless_mac = _make_discovery_info(
+            "23:07:04:37:39:E5",
             name=None,
             service_uuids=[],
         )
-        samsung_tv = _make_discovery_info(
+        s1_earbuds = _make_discovery_info(
             "11:22:33:44:55:66",
+            name="S1 Earbuds",
+            service_uuids=[],
+        )
+        samsung_tv = _make_discovery_info(
+            "11:22:33:44:55:67",
             name="[TV] Samsung",
             service_uuids=["00001800-0000-1000-8000-00805f9b34fb"],
         )
@@ -115,7 +140,16 @@ def test_async_step_user_filters_by_service_uuid_and_name():
             service_uuids=[],
         )
 
-        discovered = [d11_clone, nameless_niimbot, b21_printer_no_uuid, nameless_raw_mac, samsung_tv, xiaomi_sensor]
+        discovered = [
+            d11_clone,
+            b1_underscore,
+            b21_printer,
+            uuid_matched_device,
+            random_nameless_mac,
+            s1_earbuds,
+            samsung_tv,
+            xiaomi_sensor,
+        ]
 
         with patch(
             "custom_components.niimbot.config_flow.async_discovered_service_info",
@@ -126,12 +160,12 @@ def test_async_step_user_filters_by_service_uuid_and_name():
         assert result["type"] == "form"
         assert result["step_id"] == "user"
 
-        # Niimbot-named devices and nameless devices must be present
+        # Valid Niimbot devices should be discovered
         assert "AA:BB:CC:DD:EE:01" in flow._discovered_devices
         assert flow._discovered_devices["AA:BB:CC:DD:EE:01"].name == "D11_BF25_BLE"
 
         assert "AA:BB:CC:DD:EE:02" in flow._discovered_devices
-        assert flow._discovered_devices["AA:BB:CC:DD:EE:02"].name == "Niimbot (AA:BB:CC:DD:EE:02)"
+        assert flow._discovered_devices["AA:BB:CC:DD:EE:02"].name == "B1_G723040259"
 
         assert "AA:BB:CC:DD:EE:03" in flow._discovered_devices
         assert flow._discovered_devices["AA:BB:CC:DD:EE:03"].name == "B21-123456"
@@ -139,15 +173,17 @@ def test_async_step_user_filters_by_service_uuid_and_name():
         assert "AA:BB:CC:DD:EE:04" in flow._discovered_devices
         assert flow._discovered_devices["AA:BB:CC:DD:EE:04"].name == "Niimbot (AA:BB:CC:DD:EE:04)"
 
-        # Named non-Niimbot devices must be filtered out
+        # Random nameless rotating MACs and non-Niimbot devices must be filtered out
+        assert "23:07:04:37:39:E5" not in flow._discovered_devices
         assert "11:22:33:44:55:66" not in flow._discovered_devices
+        assert "11:22:33:44:55:67" not in flow._discovered_devices
         assert "22:33:44:55:66:77" not in flow._discovered_devices
 
     asyncio.run(_test())
 
 
 def test_async_step_user_no_devices_found():
-    """Test abort when all discovered devices are named non-Niimbot devices."""
+    """Test abort when no Niimbot devices match."""
     async def _test():
         flow = NiimbotConfigFlow()
         flow.hass = MagicMock()
@@ -157,10 +193,15 @@ def test_async_step_user_no_devices_found():
             name="[TV] Samsung",
             service_uuids=["00001800-0000-1000-8000-00805f9b34fb"],
         )
+        random_nameless_mac = _make_discovery_info(
+            "23:07:04:37:39:E5",
+            name=None,
+            service_uuids=[],
+        )
 
         with patch(
             "custom_components.niimbot.config_flow.async_discovered_service_info",
-            return_value=[samsung_tv],
+            return_value=[samsung_tv, random_nameless_mac],
         ), patch.object(flow, "_async_current_ids", return_value=set()):
             result = await flow.async_step_user()
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,6 +1,8 @@
 """Tests for Niimbot BLE config flow."""
 
 import asyncio
+import json
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.const import CONF_ADDRESS, CONF_SCAN_INTERVAL
@@ -18,52 +20,79 @@ from custom_components.niimbot.const import (
     NIIMBOT_SERVICE_UUID,
 )
 
+MANIFEST_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "custom_components", "niimbot", "manifest.json"
+)
+
 
 def _make_discovery_info(
     address: str,
-    local_name: str | None = None,
-    device_name: str | None = None,
+    name: str | None = None,
     service_uuids: list[str] | None = None,
 ):
     info = MagicMock()
     info.address = address
+    info.name = name or address
     info.advertisement = MagicMock()
-    info.advertisement.local_name = local_name
+    info.advertisement.local_name = name
     info.device = MagicMock()
-    info.device.name = device_name
+    info.device.name = name
+    info.device.address = address
     info.service_uuids = service_uuids if service_uuids is not None else []
     return info
 
 
-def test_async_step_user_filters_by_service_uuid():
-    """Test that async_step_user only lists devices containing NIIMBOT_SERVICE_UUID."""
+def test_manifest_local_name_matchers_have_no_wildcard_in_first_3_chars():
+    """Test that all local_name matchers in manifest.json obey HA's 3-char prefix rule.
+
+    Home Assistant's bluetooth indexer (_local_name_to_index_key) raises ValueError
+    if '*' or '[' appears in the first 3 characters of any local_name matcher.
+    """
+    with open(MANIFEST_PATH, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    for entry in manifest.get("bluetooth", []):
+        if local_name := entry.get("local_name"):
+            assert len(local_name) >= 3, f"Matcher too short: {local_name}"
+            prefix = local_name[:3]
+            assert "*" not in prefix and "[" not in prefix, (
+                f"Invalid matcher '{local_name}': first 3 chars '{prefix}' cannot contain wildcards"
+            )
+
+
+def test_async_step_user_filters_by_service_uuid_and_name():
+    """Test that async_step_user prioritises devices matching NIIMBOT_SERVICE_UUID or known prefixes."""
     async def _test():
         flow = NiimbotConfigFlow()
         flow.hass = MagicMock()
 
         d11_clone = _make_discovery_info(
             "AA:BB:CC:DD:EE:01",
-            local_name="D11_BF25_BLE",
+            name="D11_BF25_BLE",
             service_uuids=[NIIMBOT_SERVICE_UUID],
         )
         nameless_niimbot = _make_discovery_info(
             "AA:BB:CC:DD:EE:02",
-            local_name=None,
-            device_name=None,
+            name=None,
             service_uuids=[NIIMBOT_SERVICE_UUID],
+        )
+        b21_printer_no_uuid = _make_discovery_info(
+            "AA:BB:CC:DD:EE:03",
+            name="B21-123456",
+            service_uuids=[],
         )
         samsung_tv = _make_discovery_info(
             "11:22:33:44:55:66",
-            local_name="[TV] Samsung",
+            name="[TV] Samsung",
             service_uuids=["00001800-0000-1000-8000-00805f9b34fb"],
         )
         random_beacon = _make_discovery_info(
             "77:88:99:AA:BB:CC",
-            local_name=None,
+            name=None,
             service_uuids=[],
         )
 
-        discovered = [d11_clone, nameless_niimbot, samsung_tv, random_beacon]
+        discovered = [d11_clone, nameless_niimbot, b21_printer_no_uuid, samsung_tv, random_beacon]
 
         with patch(
             "custom_components.niimbot.config_flow.async_discovered_service_info",
@@ -74,35 +103,60 @@ def test_async_step_user_filters_by_service_uuid():
         assert result["type"] == "form"
         assert result["step_id"] == "user"
 
-        # Only the 2 Niimbot devices should be discovered
+        # The 3 Niimbot-matching devices should be discovered
         assert "AA:BB:CC:DD:EE:01" in flow._discovered_devices
         assert flow._discovered_devices["AA:BB:CC:DD:EE:01"].name == "D11_BF25_BLE"
 
         assert "AA:BB:CC:DD:EE:02" in flow._discovered_devices
         assert flow._discovered_devices["AA:BB:CC:DD:EE:02"].name == "Niimbot (AA:BB:CC:DD:EE:02)"
 
-        # Non-Niimbot devices must be filtered out
+        assert "AA:BB:CC:DD:EE:03" in flow._discovered_devices
+        assert flow._discovered_devices["AA:BB:CC:DD:EE:03"].name == "B21-123456"
+
+        # Non-Niimbot devices must be filtered out when candidates match
         assert "11:22:33:44:55:66" not in flow._discovered_devices
         assert "77:88:99:AA:BB:CC" not in flow._discovered_devices
 
     asyncio.run(_test())
 
 
-def test_async_step_user_no_devices_found():
-    """Test abort when no Niimbot devices are found."""
+def test_async_step_user_fallback_when_no_candidates_matched():
+    """Test fallback to all unconfigured devices when no candidate matches Niimbot filters."""
     async def _test():
         flow = NiimbotConfigFlow()
         flow.hass = MagicMock()
 
-        samsung_tv = _make_discovery_info(
-            "11:22:33:44:55:66",
-            local_name="[TV] Samsung",
-            service_uuids=["00001800-0000-1000-8000-00805f9b34fb"],
+        unknown_raw_device = _make_discovery_info(
+            "99:88:77:66:55:44",
+            name=None,
+            service_uuids=[],
         )
 
         with patch(
             "custom_components.niimbot.config_flow.async_discovered_service_info",
-            return_value=[samsung_tv],
+            return_value=[unknown_raw_device],
+        ), patch.object(flow, "_async_current_ids", return_value=set()):
+            result = await flow.async_step_user()
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+
+        # Fallback should list the device so user can pick by MAC
+        assert "99:88:77:66:55:44" in flow._discovered_devices
+        assert flow._discovered_devices["99:88:77:66:55:44"].name == "Niimbot (99:88:77:66:55:44)"
+
+    asyncio.run(_test())
+
+
+def test_async_step_user_no_devices_found():
+    """Test abort when no BLE devices exist at all."""
+    async def _test():
+        flow = NiimbotConfigFlow()
+        flow.hass = MagicMock()
+
+        with patch(
+            "custom_components.niimbot.config_flow.async_discovered_service_info",
+            return_value=[],
         ), patch.object(flow, "_async_current_ids", return_value=set()):
             result = await flow.async_step_user()
 
@@ -123,7 +177,7 @@ def test_async_step_user_creates_entry():
 
         info = _make_discovery_info(
             "AA:BB:CC:DD:EE:01",
-            local_name="D11_BF25_BLE",
+            name="D11_BF25_BLE",
             service_uuids=[NIIMBOT_SERVICE_UUID],
         )
         flow._discovered_devices = {"AA:BB:CC:DD:EE:01": Discovery("D11_BF25_BLE", info)}
@@ -158,7 +212,7 @@ def test_async_step_bluetooth():
 
         info = _make_discovery_info(
             "AA:BB:CC:DD:EE:01",
-            local_name="D11_BF25_BLE",
+            name="D11_BF25_BLE",
             service_uuids=[NIIMBOT_SERVICE_UUID],
         )
 
@@ -170,4 +224,5 @@ def test_async_step_bluetooth():
         assert result["step_id"] == "bluetooth_confirm"
 
     asyncio.run(_test())
+
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -60,8 +60,26 @@ def test_manifest_local_name_matchers_have_no_wildcard_in_first_3_chars():
             )
 
 
+def test_name_looks_like_niimbot_guards_mac_address():
+    """Test that _name_looks_like_niimbot does not treat MAC addresses starting with B1/C1 as model names."""
+    from custom_components.niimbot.config_flow import _name_looks_like_niimbot
+
+    # MAC address starting with B1 / C1 should NOT match model prefix
+    assert _name_looks_like_niimbot("B1:22:33:44:55:66", "B1:22:33:44:55:66") is False
+    assert _name_looks_like_niimbot("C1:22:33:44:55:66", "C1:22:33:44:55:66") is False
+
+    # Real model names should match
+    assert _name_looks_like_niimbot("B1-123456", "AA:BB:CC:DD:EE:01") is True
+    assert _name_looks_like_niimbot("D11_BF25_BLE", "AA:BB:CC:DD:EE:02") is True
+    assert _name_looks_like_niimbot("d11-test", "AA:BB:CC:DD:EE:03") is True
+
+    # Non-Niimbot device names should not match
+    assert _name_looks_like_niimbot("[TV] Samsung", "11:22:33:44:55:66") is False
+    assert _name_looks_like_niimbot("LYWSD03MMC", "22:33:44:55:66:77") is False
+
+
 def test_async_step_user_filters_by_service_uuid_and_name():
-    """Test that async_step_user prioritises devices matching NIIMBOT_SERVICE_UUID or known prefixes."""
+    """Test that async_step_user includes Niimbot devices and nameless devices while filtering non-Niimbot named devices."""
     async def _test():
         flow = NiimbotConfigFlow()
         flow.hass = MagicMock()
@@ -81,18 +99,23 @@ def test_async_step_user_filters_by_service_uuid_and_name():
             name="B21-123456",
             service_uuids=[],
         )
+        nameless_raw_mac = _make_discovery_info(
+            "AA:BB:CC:DD:EE:04",
+            name=None,
+            service_uuids=[],
+        )
         samsung_tv = _make_discovery_info(
             "11:22:33:44:55:66",
             name="[TV] Samsung",
             service_uuids=["00001800-0000-1000-8000-00805f9b34fb"],
         )
-        random_beacon = _make_discovery_info(
-            "77:88:99:AA:BB:CC",
-            name=None,
+        xiaomi_sensor = _make_discovery_info(
+            "22:33:44:55:66:77",
+            name="LYWSD03MMC",
             service_uuids=[],
         )
 
-        discovered = [d11_clone, nameless_niimbot, b21_printer_no_uuid, samsung_tv, random_beacon]
+        discovered = [d11_clone, nameless_niimbot, b21_printer_no_uuid, nameless_raw_mac, samsung_tv, xiaomi_sensor]
 
         with patch(
             "custom_components.niimbot.config_flow.async_discovered_service_info",
@@ -103,7 +126,7 @@ def test_async_step_user_filters_by_service_uuid_and_name():
         assert result["type"] == "form"
         assert result["step_id"] == "user"
 
-        # The 3 Niimbot-matching devices should be discovered
+        # Niimbot-named devices and nameless devices must be present
         assert "AA:BB:CC:DD:EE:01" in flow._discovered_devices
         assert flow._discovered_devices["AA:BB:CC:DD:EE:01"].name == "D11_BF25_BLE"
 
@@ -113,50 +136,31 @@ def test_async_step_user_filters_by_service_uuid_and_name():
         assert "AA:BB:CC:DD:EE:03" in flow._discovered_devices
         assert flow._discovered_devices["AA:BB:CC:DD:EE:03"].name == "B21-123456"
 
-        # Non-Niimbot devices must be filtered out when candidates match
+        assert "AA:BB:CC:DD:EE:04" in flow._discovered_devices
+        assert flow._discovered_devices["AA:BB:CC:DD:EE:04"].name == "Niimbot (AA:BB:CC:DD:EE:04)"
+
+        # Named non-Niimbot devices must be filtered out
         assert "11:22:33:44:55:66" not in flow._discovered_devices
-        assert "77:88:99:AA:BB:CC" not in flow._discovered_devices
-
-    asyncio.run(_test())
-
-
-def test_async_step_user_fallback_when_no_candidates_matched():
-    """Test fallback to all unconfigured devices when no candidate matches Niimbot filters."""
-    async def _test():
-        flow = NiimbotConfigFlow()
-        flow.hass = MagicMock()
-
-        unknown_raw_device = _make_discovery_info(
-            "99:88:77:66:55:44",
-            name=None,
-            service_uuids=[],
-        )
-
-        with patch(
-            "custom_components.niimbot.config_flow.async_discovered_service_info",
-            return_value=[unknown_raw_device],
-        ), patch.object(flow, "_async_current_ids", return_value=set()):
-            result = await flow.async_step_user()
-
-        assert result["type"] == "form"
-        assert result["step_id"] == "user"
-
-        # Fallback should list the device so user can pick by MAC
-        assert "99:88:77:66:55:44" in flow._discovered_devices
-        assert flow._discovered_devices["99:88:77:66:55:44"].name == "Niimbot (99:88:77:66:55:44)"
+        assert "22:33:44:55:66:77" not in flow._discovered_devices
 
     asyncio.run(_test())
 
 
 def test_async_step_user_no_devices_found():
-    """Test abort when no BLE devices exist at all."""
+    """Test abort when all discovered devices are named non-Niimbot devices."""
     async def _test():
         flow = NiimbotConfigFlow()
         flow.hass = MagicMock()
 
+        samsung_tv = _make_discovery_info(
+            "11:22:33:44:55:66",
+            name="[TV] Samsung",
+            service_uuids=["00001800-0000-1000-8000-00805f9b34fb"],
+        )
+
         with patch(
             "custom_components.niimbot.config_flow.async_discovered_service_info",
-            return_value=[],
+            return_value=[samsung_tv],
         ), patch.object(flow, "_async_current_ids", return_value=set()):
             result = await flow.async_step_user()
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,173 @@
+"""Tests for Niimbot BLE config flow."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.const import CONF_ADDRESS, CONF_SCAN_INTERVAL
+from custom_components.niimbot.config_flow import NiimbotConfigFlow, Discovery
+from custom_components.niimbot.const import (
+    CONF_CONFIRM_EVERY_NTH_PRINT_LINE,
+    CONF_KEEP_CONNECTION,
+    CONF_USE_CLOUD_LABEL_INFO,
+    CONF_WAIT_BETWEEN_EACH_PRINT_LINE,
+    DEFAULT_CONFIRM_EVERY_NTH_PRINT_LINE,
+    DEFAULT_KEEP_CONNECTION,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_USE_CLOUD_LABEL_INFO,
+    DEFAULT_WAIT_BETWEEN_EACH_PRINT_LINE,
+    NIIMBOT_SERVICE_UUID,
+)
+
+
+def _make_discovery_info(
+    address: str,
+    local_name: str | None = None,
+    device_name: str | None = None,
+    service_uuids: list[str] | None = None,
+):
+    info = MagicMock()
+    info.address = address
+    info.advertisement = MagicMock()
+    info.advertisement.local_name = local_name
+    info.device = MagicMock()
+    info.device.name = device_name
+    info.service_uuids = service_uuids if service_uuids is not None else []
+    return info
+
+
+def test_async_step_user_filters_by_service_uuid():
+    """Test that async_step_user only lists devices containing NIIMBOT_SERVICE_UUID."""
+    async def _test():
+        flow = NiimbotConfigFlow()
+        flow.hass = MagicMock()
+
+        d11_clone = _make_discovery_info(
+            "AA:BB:CC:DD:EE:01",
+            local_name="D11_BF25_BLE",
+            service_uuids=[NIIMBOT_SERVICE_UUID],
+        )
+        nameless_niimbot = _make_discovery_info(
+            "AA:BB:CC:DD:EE:02",
+            local_name=None,
+            device_name=None,
+            service_uuids=[NIIMBOT_SERVICE_UUID],
+        )
+        samsung_tv = _make_discovery_info(
+            "11:22:33:44:55:66",
+            local_name="[TV] Samsung",
+            service_uuids=["00001800-0000-1000-8000-00805f9b34fb"],
+        )
+        random_beacon = _make_discovery_info(
+            "77:88:99:AA:BB:CC",
+            local_name=None,
+            service_uuids=[],
+        )
+
+        discovered = [d11_clone, nameless_niimbot, samsung_tv, random_beacon]
+
+        with patch(
+            "custom_components.niimbot.config_flow.async_discovered_service_info",
+            return_value=discovered,
+        ), patch.object(flow, "_async_current_ids", return_value=set()):
+            result = await flow.async_step_user()
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+
+        # Only the 2 Niimbot devices should be discovered
+        assert "AA:BB:CC:DD:EE:01" in flow._discovered_devices
+        assert flow._discovered_devices["AA:BB:CC:DD:EE:01"].name == "D11_BF25_BLE"
+
+        assert "AA:BB:CC:DD:EE:02" in flow._discovered_devices
+        assert flow._discovered_devices["AA:BB:CC:DD:EE:02"].name == "Niimbot (AA:BB:CC:DD:EE:02)"
+
+        # Non-Niimbot devices must be filtered out
+        assert "11:22:33:44:55:66" not in flow._discovered_devices
+        assert "77:88:99:AA:BB:CC" not in flow._discovered_devices
+
+    asyncio.run(_test())
+
+
+def test_async_step_user_no_devices_found():
+    """Test abort when no Niimbot devices are found."""
+    async def _test():
+        flow = NiimbotConfigFlow()
+        flow.hass = MagicMock()
+
+        samsung_tv = _make_discovery_info(
+            "11:22:33:44:55:66",
+            local_name="[TV] Samsung",
+            service_uuids=["00001800-0000-1000-8000-00805f9b34fb"],
+        )
+
+        with patch(
+            "custom_components.niimbot.config_flow.async_discovered_service_info",
+            return_value=[samsung_tv],
+        ), patch.object(flow, "_async_current_ids", return_value=set()):
+            result = await flow.async_step_user()
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "no_devices_found"
+
+    asyncio.run(_test())
+
+
+def test_async_step_user_creates_entry():
+    """Test user selecting a device creates config entry."""
+    async def _test():
+        flow = NiimbotConfigFlow()
+        flow.hass = MagicMock()
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_configured = MagicMock()
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+        info = _make_discovery_info(
+            "AA:BB:CC:DD:EE:01",
+            local_name="D11_BF25_BLE",
+            service_uuids=[NIIMBOT_SERVICE_UUID],
+        )
+        flow._discovered_devices = {"AA:BB:CC:DD:EE:01": Discovery("D11_BF25_BLE", info)}
+
+        user_input = {
+            CONF_ADDRESS: "AA:BB:CC:DD:EE:01",
+            CONF_SCAN_INTERVAL: DEFAULT_SCAN_INTERVAL,
+            CONF_WAIT_BETWEEN_EACH_PRINT_LINE: DEFAULT_WAIT_BETWEEN_EACH_PRINT_LINE,
+            CONF_CONFIRM_EVERY_NTH_PRINT_LINE: DEFAULT_CONFIRM_EVERY_NTH_PRINT_LINE,
+            CONF_KEEP_CONNECTION: DEFAULT_KEEP_CONNECTION,
+            CONF_USE_CLOUD_LABEL_INFO: DEFAULT_USE_CLOUD_LABEL_INFO,
+        }
+
+        result = await flow.async_step_user(user_input=user_input)
+
+        flow.async_set_unique_id.assert_awaited_once_with("AA:BB:CC:DD:EE:01", raise_on_progress=False)
+        flow.async_create_entry.assert_called_once_with(title="D11_BF25_BLE", data=user_input)
+        assert result == {"type": "create_entry"}
+
+    asyncio.run(_test())
+
+
+def test_async_step_bluetooth():
+    """Test bluetooth automatic discovery step."""
+    async def _test():
+        flow = NiimbotConfigFlow()
+        flow.hass = MagicMock()
+        flow.context = {}
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_configured = MagicMock()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "bluetooth_confirm"})
+
+        info = _make_discovery_info(
+            "AA:BB:CC:DD:EE:01",
+            local_name="D11_BF25_BLE",
+            service_uuids=[NIIMBOT_SERVICE_UUID],
+        )
+
+        result = await flow.async_step_bluetooth(info)
+
+        flow.async_set_unique_id.assert_awaited_once_with("AA:BB:CC:DD:EE:01")
+        assert flow.context["title_placeholders"] == {"name": "D11_BF25_BLE"}
+        assert result["type"] == "form"
+        assert result["step_id"] == "bluetooth_confirm"
+
+    asyncio.run(_test())
+


### PR DESCRIPTION
## Summary
- Refs #102

### 1. Bluetooth Auto-discovery (`manifest.json`)
- Fixes Home Assistant `LOCAL_NAME_MIN_MATCH_LENGTH = 3` constraint by ensuring all `local_name` matchers have at least 3 non-wildcard characters (`B1-*`, `B1_*`, `B2-*`, `B2_*`, `A63*`, `B18*`, `B21*`, `B3S*`, `D11*`, `T2S*`).
- Broadens support for underscore-delimited printer names (such as `D11_BF25_BLE`, `B1_*`, `B2_*`, `T2S_*`, `B18_*`, `A63_*`).
- Adds `service_uuid: "e7810a71-73ae-499d-8c15-faa9aef0c3f2"` matcher.
  > Note: known Niimbot models do not advertise this UUID (verified against a real B1 advertisement: Flags + Complete Local Name only). This matcher is defensive coverage for possible variants, not a working discovery path — do not build filtering logic on it.

### 2. Manual Config Flow Filtering (`config_flow.py`)
- **Prefix Alignment with Manifest**: Uses a clean, targeted prefix tuple directly mirroring manifest matchers (`"A63"", ""B1-"", ""B1_"", ""B18"", ""B2-"", ""B2_"", ""B21"", ""B3S"", ""D11"", ""T2S"", ""NIIMBOT""`), eliminating false positive candidates from non-Niimbot devices (e.g. S1 earbuds, P1 mouse, M2 tracker, C1 sensor).
- **MAC Address Guard**: Guards `_name_looks_like_niimbot` against matching MAC addresses (e.g. `B1:...`, `C1:...`, `A8:...`) as model prefixes when `name == address`.
- **Filters Random/Rotating Nameless MACs**: Excludes random privacy MAC broadcasts that lack Niimbot names or Service UUIDs, preventing noisy and transient MAC address entries in the dropdown.
- **Clean Formatting**: Formats discovered printer titles cleanly.

### 3. Tests & Cleanups
- Reuses `SERVICE_UUID` from `.niimprint.printer` in `const.py`.
- Added `test_manifest_local_name_matchers_have_no_wildcard_in_first_3_chars()` to guarantee future matchers conform to Home Assistant's indexing rule.
- Added `test_name_prefixes_stay_in_sync_with_manifest()` to prevent prefix drift between `manifest.json` and `config_flow.py`.
- Added `test_name_looks_like_niimbot_guards_mac_address_and_avoids_false_positives()` to verify MAC collision prevention and false-positive rejection.
- Verified test suite: 108 passed.